### PR TITLE
(fix) typo in the README MONGO_URI should be MONGO_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ It is recommended to define the following options:
 - **-web.listen-address** - The listen address of the exporter (*default: ":9104"*)
 - **-log_dir** - The directory to write the log file (*default: /tmp*)
 
-To define your own MongoDB URI, use environment variable `MONGODB_URI`. If set this variable takes precedence over **-mongodb.uri** flag.
-For example: `export MONGODB_URI=mongodb://localhost:27017`
+To define your own MongoDB URL, use environment variable `MONGODB_URL`. If set this variable takes precedence over **-mongodb.uri** flag.
+For example: `export MONGODB_URL=mongodb://localhost:27017`
 
 To enable HTTP basic authentication, set environment variable `HTTP_AUTH` to user:password pair.
 For example: `export HTTP_AUTH="user:password"`
@@ -51,10 +51,10 @@ db.getSiblingDB("admin").createUser({
 })
 ```
 
-2. Set environment variable `MONGODB_URI` before starting the exporter:
+2. Set environment variable `MONGODB_URL` before starting the exporter:
 
 ```
-export MONGODB_URI=mongodb://mongodb_exporter:s3cr3tpassw0rd@localhost:27017
+export MONGODB_URL=mongodb://mongodb_exporter:s3cr3tpassw0rd@localhost:27017
 ```
 
 ### Note about how this works


### PR DESCRIPTION
The README tells you to set MONGO_URI and this doesn't work. The code is looking for MONGO_URL, updated README to remove confusion.