### PR TITLE
Build against latest version of prometheus golang-client

### DIFF
--- a/collector/mongod/asserts.go
+++ b/collector/mongod/asserts.go
@@ -5,11 +5,10 @@ import (
 )
 
 var (
-	assertsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "asserts_total",
-		Help:      "The asserts document reports the number of asserts on the database. While assert errors are typically uncommon, if there are non-zero values for the asserts, you should check the log file for the mongod process for more information. In many cases these errors are trivial, but are worth investigating.",
-	}, []string{"type"})
+	assertsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "asserts_total"),
+		"The asserts document reports the number of asserts on the database. While assert errors are typically uncommon, if there are non-zero values for the asserts, you should check the log file for the mongod process for more information. In many cases these errors are trivial, but are worth investigating.",
+	  []string{"type"}, nil)
 )
 
 // AssertsStats has the assets metrics
@@ -23,15 +22,14 @@ type AssertsStats struct {
 
 // Export exports the metrics to prometheus.
 func (asserts *AssertsStats) Export(ch chan<- prometheus.Metric) {
-	assertsTotal.WithLabelValues("regular").Set(asserts.Regular)
-	assertsTotal.WithLabelValues("warning").Set(asserts.Warning)
-	assertsTotal.WithLabelValues("msg").Set(asserts.Msg)
-	assertsTotal.WithLabelValues("user").Set(asserts.User)
-	assertsTotal.WithLabelValues("rollovers").Set(asserts.Rollovers)
-	assertsTotal.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.Regular, "regular")
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.Warning, "warning")
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.Msg, "msg")
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.User, "user")
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.Rollovers, "rollovers")
 }
 
 // Describe describes the metrics for prometheus
 func (asserts *AssertsStats) Describe(ch chan<- *prometheus.Desc) {
-	assertsTotal.Describe(ch)
+	ch <- assertsTotal
 }

--- a/collector/mongod/background_flushing.go
+++ b/collector/mongod/background_flushing.go
@@ -7,18 +7,14 @@ import (
 )
 
 var (
-	backgroundFlushingflushesTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "background_flushing",
-		Name:      "flushes_total",
-		Help:      "flushes is a counter that collects the number of times the database has flushed all writes to disk. This value will grow as database runs for longer periods of time",
-	})
-	backgroundFlushingtotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "background_flushing",
-		Name:      "total_milliseconds",
-		Help:      "The total_ms value provides the total number of milliseconds (ms) that the mongod processes have spent writing (i.e. flushing) data to disk. Because this is an absolute value, consider the value offlushes and average_ms to provide better context for this datum",
-	})
+	backgroundFlushingflushesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "background_flushing", "flushes_total"),
+		"flushes is a counter that collects the number of times the database has flushed all writes to disk. This value will grow as database runs for longer periods of time",
+	  nil, nil)
+	backgroundFlushingtotalMilliseconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "background_flushing", "total_milliseconds"),
+		"The total_ms value provides the total number of milliseconds (ms) that the mongod processes have spent writing (i.e. flushing) data to disk. Because this is an absolute value, consider the value offlushes and average_ms to provide better context for this datum",
+		nil, nil)
 	backgroundFlushingaverageMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
@@ -50,14 +46,12 @@ type FlushStats struct {
 
 // Export exports the metrics for prometheus.
 func (flushStats *FlushStats) Export(ch chan<- prometheus.Metric) {
-	backgroundFlushingflushesTotal.Set(flushStats.Flushes)
-	backgroundFlushingtotalMilliseconds.Set(flushStats.TotalMs)
+	ch <- prometheus.MustNewConstMetric(backgroundFlushingflushesTotal, prometheus.CounterValue, flushStats.Flushes)
+	ch <- prometheus.MustNewConstMetric(backgroundFlushingtotalMilliseconds, prometheus.CounterValue, flushStats.TotalMs)
 	backgroundFlushingaverageMilliseconds.Set(flushStats.AverageMs)
 	backgroundFlushinglastMilliseconds.Set(flushStats.LastMs)
 	backgroundFlushinglastFinishedTime.Set(float64(flushStats.LastFinished.Unix()))
 
-	backgroundFlushingflushesTotal.Collect(ch)
-	backgroundFlushingtotalMilliseconds.Collect(ch)
 	backgroundFlushingaverageMilliseconds.Collect(ch)
 	backgroundFlushinglastMilliseconds.Collect(ch)
 	backgroundFlushinglastFinishedTime.Collect(ch)
@@ -65,8 +59,8 @@ func (flushStats *FlushStats) Export(ch chan<- prometheus.Metric) {
 
 // Describe describes the metrics for prometheus
 func (flushStats *FlushStats) Describe(ch chan<- *prometheus.Desc) {
-	backgroundFlushingflushesTotal.Describe(ch)
-	backgroundFlushingtotalMilliseconds.Describe(ch)
+	ch <- backgroundFlushingflushesTotal
+	ch <- backgroundFlushingtotalMilliseconds
 	backgroundFlushingaverageMilliseconds.Describe(ch)
 	backgroundFlushinglastMilliseconds.Describe(ch)
 	backgroundFlushinglastFinishedTime.Describe(ch)

--- a/collector/mongod/connections.go
+++ b/collector/mongod/connections.go
@@ -12,12 +12,10 @@ var (
 	}, []string{"state"})
 )
 var (
-	connectionsMetricsCreatedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "connections_metrics",
-		Name:      "created_total",
-		Help:      "totalCreated provides a count of all incoming connections created to the server. This number includes connections that have since closed",
-	})
+	connectionsMetricsCreatedTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "connections_metrics", "created_total"),
+		"totalCreated provides a count of all incoming connections created to the server. This number includes connections that have since closed",
+		nil, nil)
 )
 
 // ConnectionStats are connections metrics
@@ -33,12 +31,11 @@ func (connectionStats *ConnectionStats) Export(ch chan<- prometheus.Metric) {
 	connections.WithLabelValues("available").Set(connectionStats.Available)
 	connections.Collect(ch)
 
-	connectionsMetricsCreatedTotal.Set(connectionStats.TotalCreated)
-	connectionsMetricsCreatedTotal.Collect(ch)
+	prometheus.MustNewConstMetric(connectionsMetricsCreatedTotal, prometheus.CounterValue, connectionStats.TotalCreated)
 }
 
 // Describe describes the metrics for prometheus
 func (connectionStats *ConnectionStats) Describe(ch chan<- *prometheus.Desc) {
 	connections.Describe(ch)
-	connectionsMetricsCreatedTotal.Describe(ch)
+	ch <- connectionsMetricsCreatedTotal
 }

--- a/collector/mongod/index_counters.go
+++ b/collector/mongod/index_counters.go
@@ -14,11 +14,10 @@ var (
 )
 
 var (
-	indexCountersTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "index_counters_total",
-		Help:      "Total indexes by type",
-	}, []string{"type"})
+	indexCountersTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "index_counters_total"),
+		"Total indexes by type",
+	  []string{"type"}, nil)
 )
 
 //IndexCounterStats index counter stats
@@ -32,20 +31,19 @@ type IndexCounterStats struct {
 
 // Export exports the data to prometheus.
 func (indexCountersStats *IndexCounterStats) Export(ch chan<- prometheus.Metric) {
-	indexCountersTotal.WithLabelValues("accesses").Set(indexCountersStats.Accesses)
-	indexCountersTotal.WithLabelValues("hits").Set(indexCountersStats.Hits)
-	indexCountersTotal.WithLabelValues("misses").Set(indexCountersStats.Misses)
-	indexCountersTotal.WithLabelValues("resets").Set(indexCountersStats.Resets)
+	ch <- prometheus.MustNewConstMetric(indexCountersTotal, prometheus.CounterValue, indexCountersStats.Accesses, "accesses")
+	ch <- prometheus.MustNewConstMetric(indexCountersTotal, prometheus.CounterValue, indexCountersStats.Hits, "hits")
+	ch <- prometheus.MustNewConstMetric(indexCountersTotal, prometheus.CounterValue, indexCountersStats.Misses, "misses")
+	ch <- prometheus.MustNewConstMetric(indexCountersTotal, prometheus.CounterValue, indexCountersStats.Resets, "resets")
 
 	indexCountersMissRatio.Set(indexCountersStats.MissRatio)
 
-	indexCountersTotal.Collect(ch)
 	indexCountersMissRatio.Collect(ch)
 
 }
 
 // Describe describes the metrics for prometheus
 func (indexCountersStats *IndexCounterStats) Describe(ch chan<- *prometheus.Desc) {
-	indexCountersTotal.Describe(ch)
+	ch <- indexCountersTotal
 	indexCountersMissRatio.Describe(ch)
 }

--- a/collector/mongod/locks.go
+++ b/collector/mongod/locks.go
@@ -5,25 +5,22 @@ import (
 )
 
 var (
-	locksTimeLockedGlobalMicrosecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "locks_time_locked_global_microseconds_total",
-		Help:      "amount of time in microseconds that any database has held the global lock",
-	}, []string{"type", "database"})
+	locksTimeLockedGlobalMicrosecondsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "locks_time_locked_global_microseconds_total"),
+		"amount of time in microseconds that any database has held the global lock",
+	  []string{"type", "database"}, nil)
 )
 var (
-	locksTimeLockedLocalMicrosecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "locks_time_locked_local_microseconds_total",
-		Help:      "amount of time in microseconds that any database has held the local lock",
-	}, []string{"type", "database"})
+	locksTimeLockedLocalMicrosecondsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "locks_time_locked_local_microseconds_total"),
+		"amount of time in microseconds that any database has held the local lock",
+	  []string{"type", "database"}, nil)
 )
 var (
-	locksTimeAcquiringGlobalMicrosecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "locks_time_acquiring_global_microseconds_total",
-		Help:      "amount of time in microseconds that any database has spent waiting for the global lock",
-	}, []string{"type", "database"})
+	locksTimeAcquiringGlobalMicrosecondsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "locks_time_acquiring_global_microseconds_total"),
+		"amount of time in microseconds that any database has spent waiting for the global lock",
+	  []string{"type", "database"}, nil)
 )
 
 // LockStatsMap is a map of lock stats
@@ -50,24 +47,20 @@ func (locks LockStatsMap) Export(ch chan<- prometheus.Metric) {
 			key = "dot"
 		}
 
-		locksTimeLockedGlobalMicrosecondsTotal.WithLabelValues("read", key).Set(locks.TimeLockedMicros.Read)
-		locksTimeLockedGlobalMicrosecondsTotal.WithLabelValues("write", key).Set(locks.TimeLockedMicros.Write)
+		ch <- prometheus.MustNewConstMetric(locksTimeLockedGlobalMicrosecondsTotal, prometheus.CounterValue, locks.TimeLockedMicros.Read, "read", key)
+		ch <- prometheus.MustNewConstMetric(locksTimeLockedGlobalMicrosecondsTotal, prometheus.CounterValue, locks.TimeLockedMicros.Write, "write", key)
 
-		locksTimeLockedLocalMicrosecondsTotal.WithLabelValues("read", key).Set(locks.TimeLockedMicros.ReadLower)
-		locksTimeLockedLocalMicrosecondsTotal.WithLabelValues("write", key).Set(locks.TimeLockedMicros.WriteLower)
+		ch <- prometheus.MustNewConstMetric(locksTimeLockedLocalMicrosecondsTotal, prometheus.CounterValue, locks.TimeLockedMicros.ReadLower, "read", key)
+		ch <- prometheus.MustNewConstMetric(locksTimeLockedLocalMicrosecondsTotal, prometheus.CounterValue, locks.TimeLockedMicros.WriteLower, "write", key)
 
-		locksTimeAcquiringGlobalMicrosecondsTotal.WithLabelValues("read", key).Set(locks.TimeAcquiringMicros.ReadLower)
-		locksTimeAcquiringGlobalMicrosecondsTotal.WithLabelValues("write", key).Set(locks.TimeAcquiringMicros.WriteLower)
+		ch <- prometheus.MustNewConstMetric(locksTimeAcquiringGlobalMicrosecondsTotal, prometheus.CounterValue, locks.TimeAcquiringMicros.ReadLower, "read", key)
+		ch <- prometheus.MustNewConstMetric(locksTimeAcquiringGlobalMicrosecondsTotal, prometheus.CounterValue, locks.TimeAcquiringMicros.WriteLower, "write", key)
 	}
-
-	locksTimeLockedGlobalMicrosecondsTotal.Collect(ch)
-	locksTimeLockedLocalMicrosecondsTotal.Collect(ch)
-	locksTimeAcquiringGlobalMicrosecondsTotal.Collect(ch)
 }
 
 // Describe describes the metrics for prometheus
 func (locks LockStatsMap) Describe(ch chan<- *prometheus.Desc) {
-	locksTimeLockedGlobalMicrosecondsTotal.Describe(ch)
-	locksTimeLockedLocalMicrosecondsTotal.Describe(ch)
-	locksTimeAcquiringGlobalMicrosecondsTotal.Describe(ch)
+	ch <- locksTimeLockedGlobalMicrosecondsTotal
+	ch <- locksTimeLockedLocalMicrosecondsTotal
+	ch <- locksTimeAcquiringGlobalMicrosecondsTotal
 }

--- a/collector/mongod/metrics.go
+++ b/collector/mongod/metrics.go
@@ -5,12 +5,10 @@ import (
 )
 
 var (
-	metricsCursorTimedOutTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_cursor",
-		Name:      "timed_out_total",
-		Help:      "timedOut provides the total number of cursors that have timed out since the server process started. If this number is large or growing at a regular rate, this may indicate an application error",
-	})
+	metricsCursorTimedOutTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_cursor", "timed_out_total"),
+		"timedOut provides the total number of cursors that have timed out since the server process started. If this number is large or growing at a regular rate, this may indicate an application error",
+	  nil, nil)
 )
 var (
 	metricsCursorOpen = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -20,11 +18,10 @@ var (
 	}, []string{"state"})
 )
 var (
-	metricsDocumentTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "metrics_document_total",
-		Help:      "The document holds a document of that reflect document access and modification patterns and data use. Compare these values to the data in the opcounters document, which track total number of operations",
-	}, []string{"state"})
+	metricsDocumentTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "metrics_document_total"),
+		"The document holds a document of that reflect document access and modification patterns and data use. Compare these values to the data in the opcounters document, which track total number of operations",
+	  []string{"state"}, nil)
 )
 var (
 	metricsGetLastErrorWtimeNumTotal = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -33,64 +30,50 @@ var (
 		Name:      "num_total",
 		Help:      "num reports the total number of getLastError operations with a specified write concern (i.e. w) that wait for one or more members of a replica set to acknowledge the write operation (i.e. a w value greater than 1.)",
 	})
-	metricsGetLastErrorWtimeTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_get_last_error_wtime",
-		Name:      "total_milliseconds",
-		Help:      "total_millis reports the total amount of time in milliseconds that the mongod has spent performing getLastError operations with write concern (i.e. w) that wait for one or more members of a replica set to acknowledge the write operation (i.e. a w value greater than 1.)",
-	})
+	metricsGetLastErrorWtimeTotalMilliseconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_get_last_error_wtime", "total_milliseconds"),
+		"total_millis reports the total amount of time in milliseconds that the mongod has spent performing getLastError operations with write concern (i.e. w) that wait for one or more members of a replica set to acknowledge the write operation (i.e. a w value greater than 1.)",
+	  nil, nil)
 )
 var (
-	metricsGetLastErrorWtimeoutsTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_get_last_error",
-		Name:      "wtimeouts_total",
-		Help:      "wtimeouts reports the number of times that write concern operations have timed out as a result of the wtimeout threshold to getLastError.",
-	})
+	metricsGetLastErrorWtimeoutsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_get_last_error", "wtimeouts_total"),
+		"wtimeouts reports the number of times that write concern operations have timed out as a result of the wtimeout threshold to getLastError.",
+	  nil, nil)
 )
 var (
-	metricsOperationTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "metrics_operation_total",
-		Help:      "operation is a sub-document that holds counters for several types of update and query operations that MongoDB handles using special operation types",
-	}, []string{"type"})
+	metricsOperationTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "metrics_operation_total"),
+		"operation is a sub-document that holds counters for several types of update and query operations that MongoDB handles using special operation types",
+	  []string{"type"}, nil)
 )
 var (
-	metricsQueryExecutorTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "metrics_query_executor_total",
-		Help:      "queryExecutor is a document that reports data from the query execution system",
-	}, []string{"state"})
+	metricsQueryExecutorTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "metrics_query_executor_total"),
+		"queryExecutor is a document that reports data from the query execution system",
+	  []string{"state"}, nil)
 )
 var (
-	metricsRecordMovesTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_record",
-		Name:      "moves_total",
-		Help:      "moves reports the total number of times documents move within the on-disk representation of the MongoDB data set. Documents move as a result of operations that increase the size of the document beyond their allocated record size",
-	})
+	metricsRecordMovesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_record", "moves_total"),
+	  "moves reports the total number of times documents move within the on-disk representation of the MongoDB data set. Documents move as a result of operations that increase the size of the document beyond their allocated record size",
+		nil, nil)
 )
 var (
-	metricsReplApplyBatchesNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_apply_batches",
-		Name:      "num_total",
-		Help:      "num reports the total number of batches applied across all databases",
-	})
-	metricsReplApplyBatchesTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_apply_batches",
-		Name:      "total_milliseconds",
-		Help:      "total_millis reports the total amount of time the mongod has spent applying operations from the oplog",
-	})
+	metricsReplApplyBatchesNumTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_apply_batches", "num_total"),
+	  "num reports the total number of batches applied across all databases",
+		nil, nil)
+	metricsReplApplyBatchesTotalMilliseconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_apply_batches", "total_milliseconds"),
+	  "total_millis reports the total amount of time the mongod has spent applying operations from the oplog",
+		nil, nil)
 )
 var (
-	metricsReplApplyOpsTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_apply",
-		Name:      "ops_total",
-		Help:      "ops reports the total number of oplog operations applied",
-	})
+	metricsReplApplyOpsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_apply", "ops_total"),
+	  "ops reports the total number of oplog operations applied",
+		nil, nil)
 )
 var (
 	metricsReplBufferCount = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -99,12 +82,10 @@ var (
 		Name:      "count",
 		Help:      "count reports the current number of operations in the oplog buffer",
 	})
-	metricsReplBufferMaxSizeBytes = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_buffer",
-		Name:      "max_size_bytes",
-		Help:      "maxSizeBytes reports the maximum size of the buffer. This value is a constant setting in the mongod, and is not configurable",
-	})
+	metricsReplBufferMaxSizeBytes = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_buffer", "max_size_bytes"),
+	  "maxSizeBytes reports the maximum size of the buffer. This value is a constant setting in the mongod, and is not configurable",
+		nil, nil)
 	metricsReplBufferSizeBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_buffer",
@@ -113,109 +94,54 @@ var (
 	})
 )
 var (
-	metricsReplNetworkGetmoresNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_network_getmores",
-		Name:      "num_total",
-		Help:      "num reports the total number of getmore operations, which are operations that request an additional set of operations from the replication sync source.",
-	})
-	metricsReplNetworkGetmoresTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_network_getmores",
-		Name:      "total_milliseconds",
-		Help:      "total_millis reports the total amount of time required to collect data from getmore operations",
-	})
+	metricsReplNetworkGetmoresNumTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_network_getmores", "num_total"),
+	  "num reports the total number of getmore operations, which are operations that request an additional set of operations from the replication sync source.",
+		nil, nil)
+	metricsReplNetworkGetmoresTotalMilliseconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_network_getmores", "total_milliseconds"),
+	  "total_millis reports the total amount of time required to collect data from getmore operations",
+		nil, nil)
 )
 var (
-	metricsReplNetworkBytesTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_network",
-		Name:      "bytes_total",
-		Help:      "bytes reports the total amount of data read from the replication sync source",
-	})
-	metricsReplNetworkOpsTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_network",
-		Name:      "ops_total",
-		Help:      "ops reports the total number of operations read from the replication source.",
-	})
-	metricsReplNetworkReadersCreatedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_network",
-		Name:      "readers_created_total",
-		Help:      "readersCreated reports the total number of oplog query processes created. MongoDB will create a new oplog query any time an error occurs in the connection, including a timeout, or a network operation. Furthermore, readersCreated will increment every time MongoDB selects a new source fore replication.",
-	})
+	metricsReplNetworkBytesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_network", "bytes_total"),
+	  "bytes reports the total amount of data read from the replication sync source",
+		nil, nil)
+	metricsReplNetworkOpsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_network", "ops_total"),
+	  "ops reports the total number of operations read from the replication source.",
+		nil, nil)
+	metricsReplNetworkReadersCreatedTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_network", "readers_created_total"),
+	  "readersCreated reports the total number of oplog query processes created. MongoDB will create a new oplog query any time an error occurs in the connection, including a timeout, or a network operation. Furthermore, readersCreated will increment every time MongoDB selects a new source fore replication.",
+		nil, nil)
 )
 var (
-	metricsReplOplogInsertNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_oplog_insert",
-		Name:      "num_total",
-		Help:      "num reports the total number of items inserted into the oplog.",
-	})
-	metricsReplOplogInsertTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_oplog_insert",
-		Name:      "total_milliseconds",
-		Help:      "total_millis reports the total amount of time spent for the mongod to insert data into the oplog.",
-	})
+	metricsReplPreloadDocsNumTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_preload_docs", "num_total"),
+	  "num reports the total number of documents loaded during the pre-fetch stage of replication",
+		nil, nil)
+	metricsReplPreloadDocsTotalMilliseconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_preload_docs", "total_milliseconds"),
+	  "total_millis reports the total amount of time spent loading documents as part of the pre-fetch stage of replication",
+		nil, nil)
 )
 var (
-	metricsReplOplogInsertBytesTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_oplog",
-		Name:      "insert_bytes_total",
-		Help:      "insertBytes the total size of documents inserted into the oplog.",
-	})
+	metricsReplPreloadIndexesNumTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_preload_indexes", "num_total"),
+	  "num reports the total number of index entries loaded by members before updating documents as part of the pre-fetch stage of replication",
+		nil, nil)
+	metricsReplPreloadIndexesTotalMilliseconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "metrics_repl_preload_indexes", "total_milliseconds"),
+	  "total_millis reports the total amount of time spent loading index entries as part of the pre-fetch stage of replication",
+		nil, nil)
 )
 var (
-	metricsReplPreloadDocsNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_preload_docs",
-		Name:      "num_total",
-		Help:      "num reports the total number of documents loaded during the pre-fetch stage of replication",
-	})
-	metricsReplPreloadDocsTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_preload_docs",
-		Name:      "total_milliseconds",
-		Help:      "total_millis reports the total amount of time spent loading documents as part of the pre-fetch stage of replication",
-	})
-)
-var (
-	metricsReplPreloadIndexesNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_preload_indexes",
-		Name:      "num_total",
-		Help:      "num reports the total number of index entries loaded by members before updating documents as part of the pre-fetch stage of replication",
-	})
-	metricsReplPreloadIndexesTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_repl_preload_indexes",
-		Name:      "total_milliseconds",
-		Help:      "total_millis reports the total amount of time spent loading index entries as part of the pre-fetch stage of replication",
-	})
-)
-var (
-	metricsStorageFreelistSearchTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "metrics_storage_freelist_search_total",
-		Help:      "metrics about searching records in the database.",
-	}, []string{"type"})
-)
-var (
-	metricsTTLDeletedDocumentsTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_ttl",
-		Name:      "deleted_documents_total",
-		Help:      "deletedDocuments reports the total number of documents deleted from collections with a ttl index.",
-	})
-	metricsTTLPassesTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "metrics_ttl",
-		Name:      "passes_total",
-		Help:      "passes reports the number of times the background process removes documents from collections with a ttl index",
-	})
+	metricsStorageFreelistSearchTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "metrics_storage_freelist_search_total"),
+		"metrics about searching records in the database.",
+	  []string{"type"}, nil)
 )
 
 // DocumentStats are the stats associated to a document.
@@ -228,10 +154,10 @@ type DocumentStats struct {
 
 // Export exposes the document stats to be consumed by the prometheus server.
 func (documentStats *DocumentStats) Export(ch chan<- prometheus.Metric) {
-	metricsDocumentTotal.WithLabelValues("deleted").Set(documentStats.Deleted)
-	metricsDocumentTotal.WithLabelValues("inserted").Set(documentStats.Inserted)
-	metricsDocumentTotal.WithLabelValues("returned").Set(documentStats.Returned)
-	metricsDocumentTotal.WithLabelValues("updated").Set(documentStats.Updated)
+	ch <- prometheus.MustNewConstMetric(metricsDocumentTotal, prometheus.CounterValue, documentStats.Deleted, "deleted")
+	ch <- prometheus.MustNewConstMetric(metricsDocumentTotal, prometheus.CounterValue, documentStats.Inserted, "inserted")
+	ch <- prometheus.MustNewConstMetric(metricsDocumentTotal, prometheus.CounterValue, documentStats.Returned, "returned")
+	ch <- prometheus.MustNewConstMetric(metricsDocumentTotal, prometheus.CounterValue, documentStats.Updated, "updated")
 }
 
 // BenchmarkStats is bechmark info about an operation.
@@ -249,9 +175,9 @@ type GetLastErrorStats struct {
 // Export exposes the get last error stats.
 func (getLastErrorStats *GetLastErrorStats) Export(ch chan<- prometheus.Metric) {
 	metricsGetLastErrorWtimeNumTotal.Set(getLastErrorStats.Wtime.Num)
-	metricsGetLastErrorWtimeTotalMilliseconds.Set(getLastErrorStats.Wtime.TotalMillis)
+	ch <- prometheus.MustNewConstMetric(metricsGetLastErrorWtimeTotalMilliseconds, prometheus.CounterValue, getLastErrorStats.Wtime.TotalMillis)
 
-	metricsGetLastErrorWtimeoutsTotal.Set(getLastErrorStats.Wtimeouts)
+	ch <- prometheus.MustNewConstMetric(metricsGetLastErrorWtimeoutsTotal, prometheus.CounterValue, getLastErrorStats.Wtimeouts)
 }
 
 // OperationStats are the stats for some kind of operations.
@@ -263,9 +189,9 @@ type OperationStats struct {
 
 // Export exports the operation stats.
 func (operationStats *OperationStats) Export(ch chan<- prometheus.Metric) {
-	metricsOperationTotal.WithLabelValues("fastmod").Set(operationStats.Fastmod)
-	metricsOperationTotal.WithLabelValues("idhack").Set(operationStats.Idhack)
-	metricsOperationTotal.WithLabelValues("scan_and_order").Set(operationStats.ScanAndOrder)
+	ch <- prometheus.MustNewConstMetric(metricsOperationTotal, prometheus.CounterValue, operationStats.Fastmod, "fastmod")
+	ch <- prometheus.MustNewConstMetric(metricsOperationTotal, prometheus.CounterValue, operationStats.Idhack, "idhack")
+	ch <- prometheus.MustNewConstMetric(metricsOperationTotal, prometheus.CounterValue, operationStats.ScanAndOrder, "scan_and_order")
 }
 
 // QueryExecutorStats are the stats associated with a query execution.
@@ -276,8 +202,8 @@ type QueryExecutorStats struct {
 
 // Export exports the query executor stats.
 func (queryExecutorStats *QueryExecutorStats) Export(ch chan<- prometheus.Metric) {
-	metricsQueryExecutorTotal.WithLabelValues("scanned").Set(queryExecutorStats.Scanned)
-	metricsQueryExecutorTotal.WithLabelValues("scanned_objects").Set(queryExecutorStats.ScannedObjects)
+	ch <- prometheus.MustNewConstMetric(metricsQueryExecutorTotal, prometheus.CounterValue, queryExecutorStats.Scanned, "scanned")
+	ch <- prometheus.MustNewConstMetric(metricsQueryExecutorTotal, prometheus.CounterValue, queryExecutorStats.ScannedObjects, "scanned_objects")
 }
 
 // RecordStats are stats associated with a record.
@@ -287,7 +213,7 @@ type RecordStats struct {
 
 // Export exposes the record stats.
 func (recordStats *RecordStats) Export(ch chan<- prometheus.Metric) {
-	metricsRecordMovesTotal.Set(recordStats.Moves)
+	ch <- prometheus.MustNewConstMetric(metricsRecordMovesTotal, prometheus.CounterValue, recordStats.Moves)
 }
 
 // ApplyStats are the stats associated with the apply operation.
@@ -298,10 +224,10 @@ type ApplyStats struct {
 
 // Export exports the apply stats
 func (applyStats *ApplyStats) Export(ch chan<- prometheus.Metric) {
-	metricsReplApplyOpsTotal.Set(applyStats.Ops)
+	ch <- prometheus.MustNewConstMetric(metricsReplApplyOpsTotal, prometheus.CounterValue, applyStats.Ops)
 
-	metricsReplApplyBatchesNumTotal.Set(applyStats.Batches.Num)
-	metricsReplApplyBatchesTotalMilliseconds.Set(applyStats.Batches.TotalMillis)
+	ch <- prometheus.MustNewConstMetric(metricsReplApplyBatchesNumTotal, prometheus.CounterValue, applyStats.Batches.Num)
+	ch <- prometheus.MustNewConstMetric(metricsReplApplyBatchesTotalMilliseconds, prometheus.CounterValue, applyStats.Batches.TotalMillis)
 }
 
 // BufferStats are the stats associated with the buffer
@@ -314,7 +240,7 @@ type BufferStats struct {
 // Export exports the buffer stats.
 func (bufferStats *BufferStats) Export(ch chan<- prometheus.Metric) {
 	metricsReplBufferCount.Set(bufferStats.Count)
-	metricsReplBufferMaxSizeBytes.Set(bufferStats.MaxSizeBytes)
+	ch <- prometheus.MustNewConstMetric(metricsReplBufferMaxSizeBytes, prometheus.CounterValue, bufferStats.MaxSizeBytes)
 	metricsReplBufferSizeBytes.Set(bufferStats.SizeBytes)
 }
 
@@ -328,12 +254,12 @@ type MetricsNetworkStats struct {
 
 // Export exposes the network stats.
 func (metricsNetworkStats *MetricsNetworkStats) Export(ch chan<- prometheus.Metric) {
-	metricsReplNetworkBytesTotal.Set(metricsNetworkStats.Bytes)
-	metricsReplNetworkOpsTotal.Set(metricsNetworkStats.Ops)
-	metricsReplNetworkReadersCreatedTotal.Set(metricsNetworkStats.ReadersCreated)
+	ch <- prometheus.MustNewConstMetric(metricsReplNetworkBytesTotal, prometheus.CounterValue, metricsNetworkStats.Bytes)
+	ch <- prometheus.MustNewConstMetric(metricsReplNetworkOpsTotal, prometheus.CounterValue, metricsNetworkStats.Ops)
+	ch <- prometheus.MustNewConstMetric(metricsReplNetworkReadersCreatedTotal, prometheus.CounterValue, metricsNetworkStats.ReadersCreated)
 
-	metricsReplNetworkGetmoresNumTotal.Set(metricsNetworkStats.GetMores.Num)
-	metricsReplNetworkGetmoresTotalMilliseconds.Set(metricsNetworkStats.GetMores.TotalMillis)
+	ch <- prometheus.MustNewConstMetric(metricsReplNetworkGetmoresNumTotal, prometheus.CounterValue, metricsNetworkStats.GetMores.Num)
+	ch <- prometheus.MustNewConstMetric(metricsReplNetworkGetmoresTotalMilliseconds, prometheus.CounterValue, metricsNetworkStats.GetMores.TotalMillis)
 }
 
 // ReplStats are the stats associated with the replication process.
@@ -360,11 +286,11 @@ type PreloadStats struct {
 
 // Export exposes the preload stats.
 func (preloadStats *PreloadStats) Export(ch chan<- prometheus.Metric) {
-	metricsReplPreloadDocsNumTotal.Set(preloadStats.Docs.Num)
-	metricsReplPreloadDocsTotalMilliseconds.Set(preloadStats.Docs.TotalMillis)
+	ch <- prometheus.MustNewConstMetric(metricsReplPreloadDocsNumTotal, prometheus.CounterValue, preloadStats.Docs.Num)
+	ch <- prometheus.MustNewConstMetric(metricsReplPreloadDocsTotalMilliseconds, prometheus.CounterValue, preloadStats.Docs.TotalMillis)
 
-	metricsReplPreloadIndexesNumTotal.Set(preloadStats.Indexes.Num)
-	metricsReplPreloadIndexesTotalMilliseconds.Set(preloadStats.Indexes.TotalMillis)
+	ch <- prometheus.MustNewConstMetric(metricsReplPreloadIndexesNumTotal, prometheus.CounterValue, preloadStats.Indexes.Num)
+	ch <- prometheus.MustNewConstMetric(metricsReplPreloadIndexesTotalMilliseconds, prometheus.CounterValue, preloadStats.Indexes.TotalMillis)
 }
 
 // StorageStats are the stats associated with the storage.
@@ -376,9 +302,9 @@ type StorageStats struct {
 
 // Export exports the storage stats.
 func (storageStats *StorageStats) Export(ch chan<- prometheus.Metric) {
-	metricsStorageFreelistSearchTotal.WithLabelValues("bucket_exhausted").Set(storageStats.BucketExhausted)
-	metricsStorageFreelistSearchTotal.WithLabelValues("requests").Set(storageStats.Requests)
-	metricsStorageFreelistSearchTotal.WithLabelValues("scanned").Set(storageStats.Scanned)
+	ch <- prometheus.MustNewConstMetric(metricsStorageFreelistSearchTotal, prometheus.CounterValue, storageStats.BucketExhausted, "bucket_exhausted")
+	ch <- prometheus.MustNewConstMetric(metricsStorageFreelistSearchTotal, prometheus.CounterValue, storageStats.Requests, "requests")
+	ch <- prometheus.MustNewConstMetric(metricsStorageFreelistSearchTotal, prometheus.CounterValue, storageStats.Scanned, "scanned")
 }
 
 // CursorStatsOpen are the stats for open cursors
@@ -396,7 +322,7 @@ type CursorStats struct {
 
 // Export exports the cursor stats.
 func (cursorStats *CursorStats) Export(ch chan<- prometheus.Metric) {
-	metricsCursorTimedOutTotal.Set(cursorStats.TimedOut)
+	ch <- prometheus.MustNewConstMetric(metricsCursorTimedOutTotal, prometheus.CounterValue, cursorStats.TimedOut)
 	metricsCursorOpen.WithLabelValues("noTimeout").Set(cursorStats.Open.NoTimeout)
 	metricsCursorOpen.WithLabelValues("pinned").Set(cursorStats.Open.Pinned)
 	metricsCursorOpen.WithLabelValues("total").Set(cursorStats.Open.Total)
@@ -441,68 +367,37 @@ func (metricsStats *MetricsStats) Export(ch chan<- prometheus.Metric) {
 		metricsStats.Cursor.Export(ch)
 	}
 
-	metricsCursorTimedOutTotal.Collect(ch)
 	metricsCursorOpen.Collect(ch)
-	metricsDocumentTotal.Collect(ch)
 	metricsGetLastErrorWtimeNumTotal.Collect(ch)
-	metricsGetLastErrorWtimeTotalMilliseconds.Collect(ch)
-	metricsGetLastErrorWtimeoutsTotal.Collect(ch)
-	metricsOperationTotal.Collect(ch)
-	metricsQueryExecutorTotal.Collect(ch)
-	metricsRecordMovesTotal.Collect(ch)
-	metricsReplApplyBatchesNumTotal.Collect(ch)
-	metricsReplApplyBatchesTotalMilliseconds.Collect(ch)
-	metricsReplApplyOpsTotal.Collect(ch)
 	metricsReplBufferCount.Collect(ch)
-	metricsReplBufferMaxSizeBytes.Collect(ch)
 	metricsReplBufferSizeBytes.Collect(ch)
-	metricsReplNetworkGetmoresNumTotal.Collect(ch)
-	metricsReplNetworkGetmoresTotalMilliseconds.Collect(ch)
-	metricsReplNetworkBytesTotal.Collect(ch)
-	metricsReplNetworkOpsTotal.Collect(ch)
-	metricsReplNetworkReadersCreatedTotal.Collect(ch)
-	metricsReplOplogInsertNumTotal.Collect(ch)
-	metricsReplOplogInsertTotalMilliseconds.Collect(ch)
-	metricsReplOplogInsertBytesTotal.Collect(ch)
-	metricsReplPreloadDocsNumTotal.Collect(ch)
-	metricsReplPreloadDocsTotalMilliseconds.Collect(ch)
-	metricsReplPreloadIndexesNumTotal.Collect(ch)
-	metricsReplPreloadIndexesTotalMilliseconds.Collect(ch)
-	metricsStorageFreelistSearchTotal.Collect(ch)
-	metricsTTLDeletedDocumentsTotal.Collect(ch)
-	metricsTTLPassesTotal.Collect(ch)
 }
 
 // Describe describes the metrics for prometheus
 func (metricsStats *MetricsStats) Describe(ch chan<- *prometheus.Desc) {
-	metricsCursorTimedOutTotal.Describe(ch)
+	ch <- metricsCursorTimedOutTotal
 	metricsCursorOpen.Describe(ch)
-	metricsDocumentTotal.Describe(ch)
+	ch <- metricsDocumentTotal
 	metricsGetLastErrorWtimeNumTotal.Describe(ch)
-	metricsGetLastErrorWtimeTotalMilliseconds.Describe(ch)
-	metricsGetLastErrorWtimeoutsTotal.Describe(ch)
-	metricsOperationTotal.Describe(ch)
-	metricsQueryExecutorTotal.Describe(ch)
-	metricsRecordMovesTotal.Describe(ch)
-	metricsReplApplyBatchesNumTotal.Describe(ch)
-	metricsReplApplyBatchesTotalMilliseconds.Describe(ch)
-	metricsReplApplyOpsTotal.Describe(ch)
+	ch <- metricsGetLastErrorWtimeTotalMilliseconds
+	ch <- metricsGetLastErrorWtimeoutsTotal
+	ch <- metricsOperationTotal
+	ch <- metricsQueryExecutorTotal
+	ch <- metricsRecordMovesTotal
+	ch <- metricsReplApplyBatchesNumTotal
+	ch <- metricsReplApplyBatchesTotalMilliseconds
+	ch <- metricsReplApplyOpsTotal
 	metricsReplBufferCount.Describe(ch)
-	metricsReplBufferMaxSizeBytes.Describe(ch)
+	ch <- metricsReplBufferMaxSizeBytes
 	metricsReplBufferSizeBytes.Describe(ch)
-	metricsReplNetworkGetmoresNumTotal.Describe(ch)
-	metricsReplNetworkGetmoresTotalMilliseconds.Describe(ch)
-	metricsReplNetworkBytesTotal.Describe(ch)
-	metricsReplNetworkOpsTotal.Describe(ch)
-	metricsReplNetworkReadersCreatedTotal.Describe(ch)
-	metricsReplOplogInsertNumTotal.Describe(ch)
-	metricsReplOplogInsertTotalMilliseconds.Describe(ch)
-	metricsReplOplogInsertBytesTotal.Describe(ch)
-	metricsReplPreloadDocsNumTotal.Describe(ch)
-	metricsReplPreloadDocsTotalMilliseconds.Describe(ch)
-	metricsReplPreloadIndexesNumTotal.Describe(ch)
-	metricsReplPreloadIndexesTotalMilliseconds.Describe(ch)
-	metricsStorageFreelistSearchTotal.Describe(ch)
-	metricsTTLDeletedDocumentsTotal.Describe(ch)
-	metricsTTLPassesTotal.Describe(ch)
+	ch <- metricsReplNetworkGetmoresNumTotal
+	ch <- metricsReplNetworkGetmoresTotalMilliseconds
+	ch <- metricsReplNetworkBytesTotal
+	ch <- metricsReplNetworkOpsTotal
+	ch <- metricsReplNetworkReadersCreatedTotal
+	ch <- metricsReplPreloadDocsNumTotal
+	ch <- metricsReplPreloadDocsTotalMilliseconds
+	ch <- metricsReplPreloadIndexesNumTotal
+	ch <- metricsReplPreloadIndexesTotalMilliseconds
+	ch <- metricsStorageFreelistSearchTotal
 }

--- a/collector/mongod/network.go
+++ b/collector/mongod/network.go
@@ -5,19 +5,16 @@ import (
 )
 
 var (
-	networkBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "network_bytes_total",
-		Help:      "The network data structure contains data regarding MongoDB’s network use",
-	}, []string{"state"})
+	networkBytesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "network_bytes_total"),
+		"The network data structure contains data regarding MongoDB’s network use",
+	  []string{"state"}, nil)
 )
 var (
-	networkMetricsNumRequestsTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "network_metrics",
-		Name:      "num_requests_total",
-		Help:      "The numRequests field is a counter of the total number of distinct requests that the server has received. Use this value to provide context for the bytesIn and bytesOut values to ensure that MongoDB’s network utilization is consistent with expectations and application use",
-	})
+	networkMetricsNumRequestsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "network_metrics", "num_requests_total"),
+		"The numRequests field is a counter of the total number of distinct requests that the server has received. Use this value to provide context for the bytesIn and bytesOut values to ensure that MongoDB’s network utilization is consistent with expectations and application use",
+	  nil, nil)
 )
 
 //NetworkStats network stats
@@ -29,17 +26,14 @@ type NetworkStats struct {
 
 // Export exports the data to prometheus
 func (networkStats *NetworkStats) Export(ch chan<- prometheus.Metric) {
-	networkBytesTotal.WithLabelValues("in_bytes").Set(networkStats.BytesIn)
-	networkBytesTotal.WithLabelValues("out_bytes").Set(networkStats.BytesOut)
+	ch <- prometheus.MustNewConstMetric(networkBytesTotal, prometheus.CounterValue, networkStats.BytesIn, "in_bytes")
+	ch <- prometheus.MustNewConstMetric(networkBytesTotal, prometheus.CounterValue, networkStats.BytesOut, "out_bytes")
 
-	networkMetricsNumRequestsTotal.Set(networkStats.NumRequests)
-
-	networkMetricsNumRequestsTotal.Collect(ch)
-	networkBytesTotal.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(networkMetricsNumRequestsTotal, prometheus.CounterValue, networkStats.NumRequests)
 }
 
 // Describe describes the metrics for prometheus
 func (networkStats *NetworkStats) Describe(ch chan<- *prometheus.Desc) {
-	networkMetricsNumRequestsTotal.Describe(ch)
-	networkBytesTotal.Describe(ch)
+	ch <- networkMetricsNumRequestsTotal
+	ch <- networkBytesTotal
 }

--- a/collector/mongod/op_counters.go
+++ b/collector/mongod/op_counters.go
@@ -5,18 +5,16 @@ import (
 )
 
 var (
-	opCountersTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "op_counters_total",
-		Help:      "The opcounters data structure provides an overview of database operations by type and makes it possible to analyze the load on the database in more granular manner. These numbers will grow over time and in response to database use. Analyze these values over time to track database utilization",
-	}, []string{"type"})
+	opCountersTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace,"", "op_counters_total"),
+		"The opcounters data structure provides an overview of database operations by type and makes it possible to analyze the load on the database in more granular manner. These numbers will grow over time and in response to database use. Analyze these values over time to track database utilization",
+	  []string{"type"}, nil)
 )
 var (
-	opCountersReplTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "op_counters_repl_total",
-		Help:      "The opcountersRepl data structure, similar to the opcounters data structure, provides an overview of database replication operations by type and makes it possible to analyze the load on the replica in more granular manner. These values only appear when the current host has replication enabled",
-	}, []string{"type"})
+	opCountersReplTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace,"", "op_counters_repl_total"),
+		"The opcountersRepl data structure, similar to the opcounters data structure, provides an overview of database replication operations by type and makes it possible to analyze the load on the replica in more granular manner. These values only appear when the current host has replication enabled",
+	  []string{"type"}, nil)
 )
 
 // OpcountersStats opcounters stats
@@ -31,19 +29,17 @@ type OpcountersStats struct {
 
 // Export exports the data to prometheus.
 func (opCounters *OpcountersStats) Export(ch chan<- prometheus.Metric) {
-	opCountersTotal.WithLabelValues("insert").Set(opCounters.Insert)
-	opCountersTotal.WithLabelValues("query").Set(opCounters.Query)
-	opCountersTotal.WithLabelValues("update").Set(opCounters.Update)
-	opCountersTotal.WithLabelValues("delete").Set(opCounters.Delete)
-	opCountersTotal.WithLabelValues("getmore").Set(opCounters.GetMore)
-	opCountersTotal.WithLabelValues("command").Set(opCounters.Command)
-
-	opCountersTotal.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Insert, "insert")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Query, "query")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Update, "update")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Delete, "delete")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.GetMore, "getmore")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Command, "command")
 }
 
 // Describe describes the metrics for prometheus
 func (opCounters *OpcountersStats) Describe(ch chan<- *prometheus.Desc) {
-	opCountersTotal.Describe(ch)
+	ch <- opCountersTotal
 }
 
 // OpcountersReplStats opcounters stats
@@ -58,17 +54,15 @@ type OpcountersReplStats struct {
 
 // Export exports the data to prometheus.
 func (opCounters *OpcountersReplStats) Export(ch chan<- prometheus.Metric) {
-	opCountersReplTotal.WithLabelValues("insert").Set(opCounters.Insert)
-	opCountersReplTotal.WithLabelValues("query").Set(opCounters.Query)
-	opCountersReplTotal.WithLabelValues("update").Set(opCounters.Update)
-	opCountersReplTotal.WithLabelValues("delete").Set(opCounters.Delete)
-	opCountersReplTotal.WithLabelValues("getmore").Set(opCounters.GetMore)
-	opCountersReplTotal.WithLabelValues("command").Set(opCounters.Command)
-
-	opCountersReplTotal.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Insert, "insert")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Query, "query")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Update, "update")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Delete, "delete")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.GetMore, "getmore")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Command, "command")
 }
 
 // Describe describes the metrics for prometheus
 func (opCounters *OpcountersReplStats) Describe(ch chan<- *prometheus.Desc) {
-	opCountersReplTotal.Describe(ch)
+	ch <- opCountersReplTotal
 }

--- a/collector/mongod/rocksdb.go
+++ b/collector/mongod/rocksdb.go
@@ -18,90 +18,62 @@ var (
 	billion  float64 = million * 1000
 	trillion float64 = billion * 1000
 
-	rocksDbStalledSecs = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"stalled_seconds_total",
-		Help:		"The total number of seconds RocksDB has spent stalled",
-	})
-	rocksDbStalls = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"stalls_total",
-		Help:		"The total number of stalls in RocksDB",
-	}, []string{"type"})
-	rocksDbCompactionBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"compaction_bytes_total",
-		Help:		"Total bytes processed during compaction between levels N and N+1 in RocksDB",
-	}, []string{"level", "type"})
-	rocksDbCompactionSecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"compaction_seconds_total",
-		Help:		"The time spent doing compactions between levels N and N+1 in RocksDB",
-	}, []string{"level"})
-	rocksDbCompactionsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"compactions_total",
-		Help:		"The total number of compactions between levels N and N+1 in RocksDB",
-	}, []string{"level"})
-	rocksDbBlockCacheHits = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"block_cache_hits_total",
-		Help:		"The total number of hits to the RocksDB Block Cache",
-	})
-	rocksDbBlockCacheMisses = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"block_cache_misses_total",
-		Help:		"The total number of misses to the RocksDB Block Cache",
-	})
-	rocksDbKeys = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"keys_total",
-		Help:		"The total number of RocksDB key operations",
-	}, []string{"type"})
-	rocksDbSeeks = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"seeks_total",
-		Help:		"The total number of seeks performed by RocksDB",
-	})
-	rocksDbIterations = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"iterations_total",
-		Help:		"The total number of iterations performed by RocksDB",
-	}, []string{"type"})
-	rocksDbBloomFilterUseful = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"bloom_filter_useful_total",
-		Help:		"The total number of times the RocksDB Bloom Filter was useful",
-	})
-	rocksDbBytesWritten = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"bytes_written_total",
-		Help:		"The total number of bytes written by RocksDB",
-	}, []string{"type"})
-	rocksDbBytesRead = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"bytes_read_total",
-		Help:		"The total number of bytes read by RocksDB",
-	}, []string{"type"})
-	rocksDbReadOps = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"rocksdb",
-		Name:		"reads_total",
-		Help:		"The total number of read operations in RocksDB",
-	}, []string{"level"})
+	rocksDbStalledSecs = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "stalled_seconds_total"),
+		"The total number of seconds RocksDB has spent stalled",
+		nil, nil)
+	rocksDbStalls = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "stalls_total"),
+		"The total number of stalls in RocksDB",
+	  []string{"type"}, nil)
+	rocksDbCompactionBytes = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "compaction_bytes_total"),
+		"Total bytes processed during compaction between levels N and N+1 in RocksDB",
+	  []string{"level", "type"}, nil)
+	rocksDbCompactionSecondsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "compaction_seconds_total"),
+		"The time spent doing compactions between levels N and N+1 in RocksDB",
+	  []string{"level"}, nil)
+	rocksDbCompactionsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "compactions_total"),
+		"The total number of compactions between levels N and N+1 in RocksDB",
+	  []string{"level"}, nil)
+	rocksDbBlockCacheHits = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "block_cache_hits_total"),
+		"The total number of hits to the RocksDB Block Cache",
+		nil, nil)
+	rocksDbBlockCacheMisses = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "block_cache_misses_total"),
+		"The total number of misses to the RocksDB Block Cache",
+		nil, nil)
+	rocksDbKeys = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "keys_total"),
+		"The total number of RocksDB key operations",
+	  []string{"type"}, nil)
+	rocksDbSeeks = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "seeks_total"),
+		"The total number of seeks performed by RocksDB",
+		nil, nil)
+	rocksDbIterations = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "iterations_total"),
+		"The total number of iterations performed by RocksDB",
+	  []string{"type"}, nil)
+	rocksDbBloomFilterUseful = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "bloom_filter_useful_total"),
+		"The total number of times the RocksDB Bloom Filter was useful",
+		nil, nil)
+	rocksDbBytesWritten = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "bytes_written_total"),
+		"The total number of bytes written by RocksDB",
+	  []string{"type"}, nil)
+	rocksDbBytesRead = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "bytes_read_total"),
+		"The total number of bytes read by RocksDB",
+	  []string{"type"}, nil)
+	rocksDbReadOps = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "rocksdb", "reads_total"),
+		"The total number of read operations in RocksDB",
+	  []string{"level"}, nil)
 )
 
 var (
@@ -116,109 +88,109 @@ var (
 		Subsystem:	"rocksdb",
 		Name:		"pending_memtable_flushes",
 		Help:		"The total number of MemTable flushes pending in RocksDB",
-	}) 
+	})
 	rocksDbCompactionPending = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"pending_compactions",
 		Help:		"The total number of compactions pending in RocksDB",
-	}) 
+	})
 	rocksDbBackgroundErrors = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"background_errors",
 		Help:		"The total number of background errors in RocksDB",
-	}) 
+	})
 	rocksDbMemTableBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"memtable_bytes",
 		Help:		"The current number of MemTable bytes in RocksDB",
-	}, []string{"type"}) 
+	}, []string{"type"})
 	rocksDbMemtableEntries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"memtable_entries",
 		Help:		"The current number of Memtable entries in RocksDB",
-	}, []string{"type"}) 
+	}, []string{"type"})
 	rocksDbEstimateTableReadersMem = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"estimate_table_readers_memory_bytes",
 		Help:		"The estimate RocksDB table-reader memory bytes",
-	}) 
+	})
 	rocksDbNumSnapshots = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"snapshots",
 		Help:		"The current number of snapshots in RocksDB",
-	}) 
+	})
 	rocksDbOldestSnapshotTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"oldest_snapshot_timestamp",
 		Help:		"The timestamp of the oldest snapshot in RocksDB",
-	}) 
+	})
 	rocksDbNumLiveVersions = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"live_versions",
 		Help:		"The current number of live versions in RocksDB",
-	}) 
+	})
 	rocksDbTotalLiveRecoveryUnits = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"total_live_recovery_units",
 		Help:		"The total number of live recovery units in RocksDB",
-	}) 
+	})
 	rocksDbBlockCacheUsage = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"block_cache_bytes",
 		Help:		"The current bytes used in the RocksDB Block Cache",
-	}) 
+	})
 	rocksDbTransactionEngineKeys = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"transaction_engine_keys",
 		Help:		"The current number of transaction engine keys in RocksDB",
-	}) 
+	})
 	rocksDbTransactionEngineSnapshots = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"transaction_engine_snapshots",
 		Help:		"The current number of transaction engine snapshots in RocksDB",
-	}) 
+	})
 	rocksDbWritesPerBatch = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"writes_per_batch",
 		Help:		"The number of writes per batch in RocksDB",
-	}) 
+	})
 	rocksDbWritesPerSec = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"writes_per_second",
 		Help:		"The number of writes per second in RocksDB",
-	}) 
+	})
 	rocksDbStallPercent = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"stall_percent",
 		Help:		"The percentage of time RocksDB has been stalled",
-	}) 
+	})
 	rocksDbWALWritesPerSync = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"write_ahead_log_writes_per_sync",
 		Help:		"The number of writes per Write-Ahead-Log sync in RocksDB",
-	}) 
+	})
 	rocksDbWALBytesPerSecs = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
 		Name:		"write_ahead_log_bytes_per_second",
 		Help:		"The number of bytes written per second by the Write-Ahead-Log in RocksDB",
-	}) 
+	})
 	rocksDbLevelFiles = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"rocksdb",
@@ -273,8 +245,8 @@ type RocksDbStatsCounters struct {
 	NumKeysWritten		float64	`bson:"num-keys-written"`
 	NumKeysRead		float64	`bson:"num-keys-read"`
 	NumSeeks		float64	`bson:"num-seeks"`
-	NumForwardIter		float64	`bson:"num-forward-iterations"`	
-	NumBackwardIter		float64	`bson:"num-backward-iterations"`	
+	NumForwardIter		float64	`bson:"num-forward-iterations"`
+	NumBackwardIter		float64	`bson:"num-backward-iterations"`
 	BlockCacheMisses	float64	`bson:"block-cache-misses"`
 	BlockCacheHits		float64	`bson:"block-cache-hits"`
 	BloomFilterUseful	float64 `bson:"bloom-filter-useful"`
@@ -352,7 +324,7 @@ func ParseStr(str string) float64 {
 	var multiply float64 = 1
 	var str_remove string = ""
 	if strings.Contains(str, " KB") || strings.HasSuffix(str, "KB") {
-		multiply = kilobyte 
+		multiply = kilobyte
 		str_remove = "KB"
 	} else if strings.Contains(str, " MB") || strings.HasSuffix(str, "MB") {
 		multiply = megabyte
@@ -504,7 +476,7 @@ func (stats *RocksDbStats) GetStatsLineField(section_prefix string, line_prefix 
 	return field
 }
 
-func (stats *RocksDbStats) ProcessLevelStats() {
+func (stats *RocksDbStats) ProcessLevelStats(ch chan<- prometheus.Metric) {
 	var levels []*RocksDbLevelStats
 	var is_section bool
 	for _, line := range stats.Stats {
@@ -524,10 +496,10 @@ func (stats *RocksDbStats) ProcessLevelStats() {
 			levelName = "total"
 		}
 		if levelName != "L0" {
-			rocksDbCompactionBytes.With(prometheus.Labels{"level": levelName, "type": "read"}).Set(level.ReadGB * gigabyte)
-			rocksDbCompactionBytes.With(prometheus.Labels{"level": levelName, "type": "read_n"}).Set(level.RnGB * gigabyte)
-			rocksDbCompactionBytes.With(prometheus.Labels{"level": levelName, "type": "read_np1"}).Set(level.Rnp1GB * gigabyte)
-			rocksDbCompactionBytes.With(prometheus.Labels{"level": levelName, "type": "moved"}).Set(level.MovedGB * gigabyte)
+			ch <- prometheus.MustNewConstMetric(rocksDbCompactionBytes, prometheus.CounterValue, level.ReadGB * gigabyte, levelName, "read")
+			ch <- prometheus.MustNewConstMetric(rocksDbCompactionBytes, prometheus.CounterValue, level.RnGB * gigabyte, levelName, "read_n")
+			ch <- prometheus.MustNewConstMetric(rocksDbCompactionBytes, prometheus.CounterValue, level.Rnp1GB * gigabyte, levelName, "read_np1")
+			ch <- prometheus.MustNewConstMetric(rocksDbCompactionBytes, prometheus.CounterValue, level.MovedGB * gigabyte, levelName, "moved")
 			rocksDbCompactionBytesPerSec.With(prometheus.Labels{"level": levelName, "type": "read"}).Set(level.RdMBPSec * megabyte)
 			rocksDbCompactionWriteAmplification.WithLabelValues(levelName).Set(level.WAmp)
 		}
@@ -535,32 +507,32 @@ func (stats *RocksDbStats) ProcessLevelStats() {
 		rocksDbLevelFiles.WithLabelValues(levelName).Set(level.Files.Num)
 		rocksDbCompactionThreads.WithLabelValues(levelName).Set(level.Files.CompThreads)
 		rocksDbLevelSizeBytes.WithLabelValues(levelName).Set(level.SizeMB * megabyte)
-		rocksDbCompactionSecondsTotal.WithLabelValues(levelName).Set(level.CompSec)
+		ch <- prometheus.MustNewConstMetric(rocksDbCompactionSecondsTotal, prometheus.CounterValue, level.CompSec, levelName)
 		rocksDbCompactionAvgSeconds.WithLabelValues(levelName).Set(level.AvgSec)
-		rocksDbCompactionBytes.With(prometheus.Labels{"level": levelName, "type": "write"}).Set(level.WriteGB * gigabyte)
-		rocksDbCompactionBytes.With(prometheus.Labels{"level": levelName, "type": "write_new_np1"}).Set(level.WriteGB * gigabyte)
+		ch <- prometheus.MustNewConstMetric(rocksDbCompactionBytes, prometheus.CounterValue, level.WriteGB * gigabyte, levelName, "write")
+		ch <- prometheus.MustNewConstMetric(rocksDbCompactionBytes, prometheus.CounterValue, level.WriteGB * gigabyte, levelName, "write_new_np1")
 		rocksDbCompactionBytesPerSec.With(prometheus.Labels{"level": levelName, "type": "write"}).Set(level.WrMBPSec * megabyte)
-		rocksDbCompactionsTotal.WithLabelValues(levelName).Set(level.CompCnt)
+		ch <- prometheus.MustNewConstMetric(rocksDbCompactionsTotal, prometheus.CounterValue, level.CompCnt, levelName)
 	}
 }
 
-func (stats *RocksDbStats) ProcessStalls() {
+func (stats *RocksDbStats) ProcessStalls(ch chan<- prometheus.Metric) {
 	for _, stall_line := range stats.GetStatsLine("** Compaction Stats [default] **", "Stalls(count): ") {
 		stall_split := strings.Split(stall_line, " ")
 		if len(stall_split) == 2 {
 			stall_type := stall_split[1]
 			stall_count := stall_split[0]
-			rocksDbStalls.WithLabelValues(stall_type).Set(ParseStr(stall_count))
+			ch <- prometheus.MustNewConstMetric(rocksDbStalls, prometheus.CounterValue, ParseStr(stall_count), stall_type)
 		}
 	}
 }
 
-func (stats *RocksDbStats) ProcessReadLatencyStats() {
+func (stats *RocksDbStats) ProcessReadLatencyStats(ch chan<- prometheus.Metric) {
 	for _, level_num := range []string{"0", "1", "2", "3", "4", "5", "6"} {
 		level := "L"+level_num
 		section := "** Level "+level_num+" read latency histogram (micros):"
 		if len(stats.GetStatsSection(section)) > 0 {
-			rocksDbReadOps.With(prometheus.Labels{"level": level}).Set(stats.GetStatsLineField(section, "Count: ", 0))
+			ch <- prometheus.MustNewConstMetric(rocksDbReadOps, prometheus.CounterValue, stats.GetStatsLineField(section, "Count: ", 0), level)
 			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "avg"}).Set(stats.GetStatsLineField(section, "Count: ", 2))
 			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "stddev"}).Set(stats.GetStatsLineField(section, "Count: ", 4))
 			rocksDbReadLatencyMicros.With(prometheus.Labels{"level": level, "type": "min"}).Set(stats.GetStatsLineField(section, "Min: ", 0))
@@ -576,40 +548,31 @@ func (stats *RocksDbStats) ProcessReadLatencyStats() {
 }
 
 func (stats *RocksDbStatsCounters) Describe(ch chan<- *prometheus.Desc) {
-	rocksDbBlockCacheHits.Describe(ch)
-	rocksDbBlockCacheMisses.Describe(ch)
-	rocksDbKeys.Describe(ch)
-	rocksDbSeeks.Describe(ch)
-	rocksDbIterations.Describe(ch)
-	rocksDbBloomFilterUseful.Describe(ch)
-	rocksDbBytesWritten.Describe(ch)
-	rocksDbBytesRead.Describe(ch)
+	ch <- rocksDbBlockCacheHits
+	ch <- rocksDbBlockCacheMisses
+	ch <- rocksDbKeys
+	ch <- rocksDbSeeks
+	ch <- rocksDbIterations
+	ch <- rocksDbBloomFilterUseful
+	ch <- rocksDbBytesWritten
+	ch <- rocksDbBytesRead
 }
 
 func (stats *RocksDbStatsCounters) Export(ch chan<- prometheus.Metric) {
-	rocksDbBlockCacheHits.Set(stats.BlockCacheHits)
-	rocksDbBlockCacheMisses.Set(stats.BlockCacheMisses)
-	rocksDbKeys.WithLabelValues("written").Set(stats.NumKeysWritten)
-	rocksDbKeys.WithLabelValues("read").Set(stats.NumKeysRead)
-	rocksDbSeeks.Set(stats.NumSeeks)
-	rocksDbIterations.WithLabelValues("forward").Set(stats.NumForwardIter)
-	rocksDbIterations.WithLabelValues("backward").Set(stats.NumBackwardIter)
-	rocksDbBloomFilterUseful.Set(stats.BloomFilterUseful)
-	rocksDbBytesWritten.WithLabelValues("total").Set(stats.BytesWritten)
-	rocksDbBytesWritten.WithLabelValues("flush").Set(stats.FlushBytesWritten)
-	rocksDbBytesWritten.WithLabelValues("compaction").Set(stats.CompactionBytesWritten)
-	rocksDbBytesRead.WithLabelValues("point_lookup").Set(stats.BytesReadPointLookup)
-	rocksDbBytesRead.WithLabelValues("iteration").Set(stats.BytesReadIteration)
-	rocksDbBytesRead.WithLabelValues("compation").Set(stats.CompactionBytesRead)
-
-	rocksDbBlockCacheHits.Collect(ch)
-	rocksDbBlockCacheMisses.Collect(ch)
-	rocksDbKeys.Collect(ch)
-	rocksDbSeeks.Collect(ch)
-	rocksDbIterations.Collect(ch)
-	rocksDbBloomFilterUseful.Collect(ch)
-	rocksDbBytesWritten.Collect(ch)
-	rocksDbBytesRead.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(rocksDbBlockCacheHits, prometheus.CounterValue, stats.BlockCacheHits)
+	ch <- prometheus.MustNewConstMetric(rocksDbBlockCacheMisses, prometheus.CounterValue, stats.BlockCacheMisses)
+	ch <- prometheus.MustNewConstMetric(rocksDbKeys, prometheus.CounterValue, stats.NumKeysWritten, "written")
+	ch <- prometheus.MustNewConstMetric(rocksDbKeys, prometheus.CounterValue, stats.NumKeysRead, "read")
+	ch <- prometheus.MustNewConstMetric(rocksDbSeeks, prometheus.CounterValue, stats.NumSeeks)
+	ch <- prometheus.MustNewConstMetric(rocksDbIterations, prometheus.CounterValue, stats.NumForwardIter, "forward")
+	ch <- prometheus.MustNewConstMetric(rocksDbIterations, prometheus.CounterValue, stats.NumBackwardIter, "backward")
+	ch <- prometheus.MustNewConstMetric(rocksDbBloomFilterUseful, prometheus.CounterValue, stats.BloomFilterUseful)
+	ch <- prometheus.MustNewConstMetric(rocksDbBytesWritten, prometheus.CounterValue, stats.BytesWritten, "total")
+	ch <- prometheus.MustNewConstMetric(rocksDbBytesWritten, prometheus.CounterValue, stats.FlushBytesWritten, "flush")
+	ch <- prometheus.MustNewConstMetric(rocksDbBytesWritten, prometheus.CounterValue, stats.CompactionBytesWritten, "compaction")
+	ch <- prometheus.MustNewConstMetric(rocksDbBytesRead, prometheus.CounterValue, stats.BytesReadPointLookup, "point_lookup")
+	ch <- prometheus.MustNewConstMetric(rocksDbBytesRead, prometheus.CounterValue, stats.BytesReadIteration, "iteration")
+	ch <- prometheus.MustNewConstMetric(rocksDbBytesRead, prometheus.CounterValue, stats.CompactionBytesRead, "compation")
 }
 
 func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
@@ -618,17 +581,17 @@ func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
 	rocksDbWALBytesPerSecs.Describe(ch)
 	rocksDbWALWritesPerSync.Describe(ch)
 	rocksDbStallPercent.Describe(ch)
-	rocksDbStalledSecs.Describe(ch)
+	ch <- rocksDbStalledSecs
 	rocksDbLevelFiles.Describe(ch)
 	rocksDbCompactionThreads.Describe(ch)
 	rocksDbLevelSizeBytes.Describe(ch)
 	rocksDbLevelScore.Describe(ch)
-	rocksDbCompactionBytes.Describe(ch)
+	ch <- rocksDbCompactionBytes
 	rocksDbCompactionBytesPerSec.Describe(ch)
 	rocksDbCompactionWriteAmplification.Describe(ch)
-	rocksDbCompactionSecondsTotal.Describe(ch)
+	ch <- rocksDbCompactionSecondsTotal
 	rocksDbCompactionAvgSeconds.Describe(ch)
-	rocksDbCompactionsTotal.Describe(ch)
+	ch <- rocksDbCompactionsTotal
 	rocksDbNumImmutableMemTable.Describe(ch)
 	rocksDbMemTableFlushPending.Describe(ch)
 	rocksDbCompactionPending.Describe(ch)
@@ -649,7 +612,7 @@ func (stats *RocksDbStats) Describe(ch chan<- *prometheus.Desc) {
 		stats.Counters.Describe(ch)
 
 		// read latency stats get added to 'stats' when in counter-mode
-		rocksDbReadOps.Describe(ch)
+		ch <- rocksDbReadOps
 		rocksDbReadLatencyMicros.Describe(ch)
 	}
 }
@@ -660,7 +623,7 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	rocksDbWritesPerSec.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative writes: ", 5))
 	rocksDbWALBytesPerSecs.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative WAL: ", 4))
 	rocksDbWALWritesPerSync.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative WAL: ", 2))
-	rocksDbStalledSecs.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative stall: ", 0))
+	ch <- prometheus.MustNewConstMetric(rocksDbStalledSecs, prometheus.CounterValue, stats.GetStatsLineField("** DB Stats **", "Cumulative stall: ", 0))
 	rocksDbStallPercent.Set(stats.GetStatsLineField("** DB Stats **", "Cumulative stall: ", 1))
 
 	// stats from db.serverStatus().rocksdb (parsed):
@@ -684,26 +647,23 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	rocksDbTransactionEngineSnapshots.Set(stats.TransactionEngineSnapshots)
 
 	// process per-level stats in to vectors:
-	stats.ProcessLevelStats()
+	stats.ProcessLevelStats(ch)
 
 	// process stall counts into a vector:
-	stats.ProcessStalls()
+	stats.ProcessStalls(ch)
 
 	rocksDbWritesPerBatch.Collect(ch)
 	rocksDbWritesPerSec.Collect(ch)
 	rocksDbWALBytesPerSecs.Collect(ch)
 	rocksDbWALWritesPerSync.Collect(ch)
 	rocksDbStallPercent.Collect(ch)
-	rocksDbStalledSecs.Collect(ch)
 	rocksDbLevelFiles.Collect(ch)
 	rocksDbCompactionThreads.Collect(ch)
 	rocksDbLevelSizeBytes.Collect(ch)
 	rocksDbLevelScore.Collect(ch)
 	rocksDbCompactionBytesPerSec.Collect(ch)
 	rocksDbCompactionWriteAmplification.Collect(ch)
-	rocksDbCompactionSecondsTotal.Collect(ch)
 	rocksDbCompactionAvgSeconds.Collect(ch)
-	rocksDbCompactionsTotal.Collect(ch)
 	rocksDbNumImmutableMemTable.Collect(ch)
 	rocksDbMemTableFlushPending.Collect(ch)
 	rocksDbCompactionPending.Collect(ch)
@@ -718,15 +678,13 @@ func (stats *RocksDbStats) Export(ch chan<- prometheus.Metric) {
 	rocksDbMemTableBytes.Collect(ch)
 	rocksDbEstimateTableReadersMem.Collect(ch)
 	rocksDbBlockCacheUsage.Collect(ch)
-	rocksDbStalls.Collect(ch)
 
 	// optional RocksDB counters
 	if stats.Counters != nil {
 		stats.Counters.Export(ch)
 
 		// read latency stats get added to 'stats' when in counter-mode
-		stats.ProcessReadLatencyStats()
-		rocksDbReadOps.Collect(ch)
+		stats.ProcessReadLatencyStats(ch)
 		rocksDbReadLatencyMicros.Collect(ch)
 	}
 }

--- a/collector/mongod/server_status.go
+++ b/collector/mongod/server_status.go
@@ -10,24 +10,18 @@ import (
 )
 
 var (
-	instanceUptimeSeconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "instance",
-		Name:      "uptime_seconds",
-		Help:      "The value of the uptime field corresponds to the number of seconds that the mongos or mongod process has been active.",
-	})
-	instanceUptimeEstimateSeconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "instance",
-		Name:      "uptime_estimate_seconds",
-		Help:      "uptimeEstimate provides the uptime as calculated from MongoDB's internal course-grained time keeping system.",
-	})
-	instanceLocalTime = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "instance",
-		Name:      "local_time",
-		Help:      "The localTime value is the current time, according to the server, in UTC specified in an ISODate format.",
-	})
+	instanceUptimeSeconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "instance", "uptime_seconds"),
+		"The value of the uptime field corresponds to the number of seconds that the mongos or mongod process has been active.",
+		nil, nil)
+	instanceUptimeEstimateSeconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "instance", "uptime_estimate_seconds"),
+		"uptimeEstimate provides the uptime as calculated from MongoDB's internal course-grained time keeping system.",
+		nil, nil)
+	instanceLocalTime = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "instance", "local_time"),
+		"The localTime value is the current time, according to the server, in UTC specified in an ISODate format.",
+		nil, nil)
 )
 
 // ServerStatus keeps the data returned by the serverStatus() method.
@@ -69,12 +63,9 @@ type ServerStatus struct {
 
 // Export exports the server status to be consumed by prometheus.
 func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
-	instanceUptimeSeconds.Set(status.Uptime)
-	instanceUptimeEstimateSeconds.Set(status.Uptime)
-	instanceLocalTime.Set(float64(status.LocalTime.Unix()))
-	instanceUptimeSeconds.Collect(ch)
-	instanceUptimeEstimateSeconds.Collect(ch)
-	instanceLocalTime.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(instanceUptimeSeconds, prometheus.CounterValue, status.Uptime)
+	ch <- prometheus.MustNewConstMetric(instanceUptimeEstimateSeconds, prometheus.CounterValue, status.Uptime)
+	ch <- prometheus.MustNewConstMetric(instanceLocalTime, prometheus.CounterValue, float64(status.LocalTime.Unix()))
 
 	if status.Asserts != nil {
 		status.Asserts.Export(ch)
@@ -134,9 +125,9 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 
 // Describe describes the server status for prometheus.
 func (status *ServerStatus) Describe(ch chan<- *prometheus.Desc) {
-	instanceUptimeSeconds.Describe(ch)
-	instanceUptimeEstimateSeconds.Describe(ch)
-	instanceLocalTime.Describe(ch)
+	ch <- instanceUptimeSeconds
+	ch <- instanceUptimeEstimateSeconds
+	ch <- instanceLocalTime
 
 	if status.Asserts != nil {
 		status.Asserts.Describe(ch)

--- a/collector/mongod/storage_engine.go
+++ b/collector/mongod/storage_engine.go
@@ -5,11 +5,10 @@ import (
 )
 
 var (
-	storageEngine = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "storage_engine",
-		Help:      "The storage engine used by the MongoDB instance",
-	}, []string{"engine"})
+	storageEngine = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "storage_engine"),
+		"The storage engine used by the MongoDB instance",
+		[]string{"engine"}, nil)
 )
 
 // StorageEngineStats
@@ -19,11 +18,10 @@ type StorageEngineStats struct {
 
 // Export exports the data to prometheus.
 func (stats *StorageEngineStats) Export(ch chan<- prometheus.Metric) {
-	storageEngine.WithLabelValues(stats.Name).Set(1)
-	storageEngine.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(storageEngine, prometheus.CounterValue, 1, stats.Name)
 }
 
 // Describe describes the metrics for prometheus
 func (stats *StorageEngineStats) Describe(ch chan<- *prometheus.Desc) {
-	storageEngine.Describe(ch)
+	ch <- storageEngine
 }

--- a/collector/mongod/wiredtiger.go
+++ b/collector/mongod/wiredtiger.go
@@ -5,18 +5,14 @@ import(
 )
 
 var (
-	wtBlockManagerBlocksTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_blockmanager",
-		Name:		"blocks_total",
-		Help:		"The total number of blocks read by the WiredTiger BlockManager",
-	}, []string{"type"})
-	wtBlockManagerBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_blockmanager",
-		Name:		"bytes_total",
-		Help:		"The total number of bytes read by the WiredTiger BlockManager",
-	}, []string{"type"})
+	wtBlockManagerBlocksTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_blockmanager", "blocks_total"),
+		"The total number of blocks read by the WiredTiger BlockManager",
+	  []string{"type"}, nil)
+	wtBlockManagerBytesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_blockmanager", "bytes_total"),
+		"The total number of bytes read by the WiredTiger BlockManager",
+	  []string{"type"}, nil)
 )
 
 var (
@@ -26,12 +22,10 @@ var (
 		Name:		"pages",
 		Help:		"The current number of pages in the WiredTiger Cache",
 	}, []string{"type"})
-	wtCachePagesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"pages_total",
-		Help:		"The total number of pages read into/from the WiredTiger Cache",
-	}, []string{"type"})
+	wtCachePagesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_cache", "pages_total"),
+		"The total number of pages read into/from the WiredTiger Cache",
+	  []string{"type"}, nil)
 	wtCacheBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"wiredtiger_cache",
@@ -44,18 +38,14 @@ var (
 		Name:		"max_bytes",
 		Help:		"The maximum size of data in the WiredTiger Cache in bytes",
 	})
-	wtCacheBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"bytes_total",
-		Help:		"The total number of bytes read into/from the WiredTiger Cache",
-	}, []string{"type"})
-	wtCacheEvictedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"evicted_total",
-		Help:		"The total number of pages evicted from the WiredTiger Cache",
-	}, []string{"type"})
+	wtCacheBytesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_cache", "bytes_total"),
+		"The total number of bytes read into/from the WiredTiger Cache",
+	  []string{"type"}, nil)
+	wtCacheEvictedTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_cache", "evicted_total"),
+		"The total number of pages evicted from the WiredTiger Cache",
+	  []string{"type"}, nil)
 	wtCachePercentOverhead = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"wiredtiger_cache",
@@ -65,18 +55,14 @@ var (
 )
 
 var(
-	wtTransactionsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_transactions",
-		Name:		"total",
-		Help:		"The total number of transactions WiredTiger has handled",
-	}, []string{"type"})
-	wtTransactionsTotalCheckpointMs = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_transactions",
-		Name:		"checkpoint_milliseconds_total",
-		Help:		"The total time in milliseconds transactions have checkpointed in WiredTiger",
-	})
+	wtTransactionsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_transactions", "total"),
+		"The total number of transactions WiredTiger has handled",
+	  []string{"type"}, nil)
+	wtTransactionsTotalCheckpointMs = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_transactions", "checkpoint_milliseconds_total"),
+		"The total time in milliseconds transactions have checkpointed in WiredTiger",
+		nil, nil)
 	wtTransactionsCheckpointMs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:	Namespace,
 		Subsystem:	"wiredtiger_transactions",
@@ -92,30 +78,22 @@ var(
 )
 
 var(
-	wtLogRecordsScannedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_log",
-                Name:           "records_scanned_total",
-                Help:           "The total number of records scanned by log scan in the WiredTiger log",
-        })
-	wtLogRecordsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_log",
-                Name:           "records_total",
-                Help:           "The total number of compressed/uncompressed records written to the WiredTiger log",
-        }, []string{"type"})
-	wtLogBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_log",
-                Name:           "bytes_total",
-                Help:           "The total number of bytes written to the WiredTiger log",
-        }, []string{"type"})
-	wtLogOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_log",
-                Name:           "operations_total",
-                Help:           "The total number of WiredTiger log operations",
-        }, []string{"type"})
+	wtLogRecordsScannedTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_log", "records_scanned_total"),
+    "The total number of records scanned by log scan in the WiredTiger log",
+    nil, nil)
+	wtLogRecordsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_log", "records_total"),
+    "The total number of compressed/uncompressed records written to the WiredTiger log",
+    []string{"type"}, nil)
+	wtLogBytesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_log", "bytes_total"),
+    "The total number of bytes written to the WiredTiger log",
+    []string{"type"}, nil)
+	wtLogOperationsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "wiredtiger_log", "operations_total"),
+    "The total number of WiredTiger log operations",
+    []string{"type"}, nil)
 )
 
 var(
@@ -166,18 +144,18 @@ type WTBlockManagerStats struct {
 }
 
 func (stats *WTBlockManagerStats) Export(ch chan<- prometheus.Metric) {
-	wtBlockManagerBlocksTotal.WithLabelValues("read").Set(stats.BlocksRead)
-	wtBlockManagerBlocksTotal.WithLabelValues("read_mapped").Set(stats.MappedBlocksRead)
-	wtBlockManagerBlocksTotal.WithLabelValues("pre_loaded").Set(stats.BlocksPreLoaded)
-	wtBlockManagerBlocksTotal.WithLabelValues("written").Set(stats.BlocksWritten)
-	wtBlockManagerBytesTotal.WithLabelValues("read").Set(stats.BytesRead)
-	wtBlockManagerBytesTotal.WithLabelValues("read_mapped").Set(stats.MappedBytesRead)
-	wtBlockManagerBytesTotal.WithLabelValues("written").Set(stats.BytesWritten)
+	ch <- prometheus.MustNewConstMetric(wtBlockManagerBlocksTotal, prometheus.CounterValue, stats.BlocksRead, "read")
+	ch <- prometheus.MustNewConstMetric(wtBlockManagerBlocksTotal, prometheus.CounterValue, stats.MappedBlocksRead, "read_mapped")
+	ch <- prometheus.MustNewConstMetric(wtBlockManagerBlocksTotal, prometheus.CounterValue, stats.BlocksPreLoaded, "pre_loaded")
+	ch <- prometheus.MustNewConstMetric(wtBlockManagerBlocksTotal, prometheus.CounterValue, stats.BlocksWritten, "written")
+	ch <- prometheus.MustNewConstMetric(wtBlockManagerBytesTotal, prometheus.CounterValue, stats.BytesRead, "read")
+	ch <- prometheus.MustNewConstMetric(wtBlockManagerBytesTotal, prometheus.CounterValue, stats.MappedBytesRead, "read_mapped")
+	ch <- prometheus.MustNewConstMetric(wtBlockManagerBytesTotal, prometheus.CounterValue, stats.BytesWritten, "written")
 }
 
 func (stats *WTBlockManagerStats) Describe(ch chan<- *prometheus.Desc) {
-	wtBlockManagerBlocksTotal.Describe(ch)
-	wtBlockManagerBytesTotal.Describe(ch)
+	ch <- wtBlockManagerBlocksTotal
+	ch <- wtBlockManagerBytesTotal
 }
 
 // cache stats
@@ -197,12 +175,12 @@ type WTCacheStats struct {
 }
 
 func (stats *WTCacheStats) Export(ch chan<- prometheus.Metric) {
-	wtCachePagesTotal.WithLabelValues("read").Set(stats.PagesReadInto)
-	wtCachePagesTotal.WithLabelValues("written").Set(stats.PagesWrittenFrom)
-	wtCacheBytesTotal.WithLabelValues("read").Set(stats.BytesReadInto)
-	wtCacheBytesTotal.WithLabelValues("written").Set(stats.BytesWrittenFrom)
-	wtCacheEvictedTotal.WithLabelValues("modified").Set(stats.EvictedModified)
-	wtCacheEvictedTotal.WithLabelValues("unmodified").Set(stats.EvictedUnmodified)
+	ch <- prometheus.MustNewConstMetric(wtCachePagesTotal, prometheus.CounterValue, stats.PagesReadInto, "read")
+	ch <- prometheus.MustNewConstMetric(wtCachePagesTotal, prometheus.CounterValue, stats.PagesWrittenFrom, "written")
+	ch <- prometheus.MustNewConstMetric(wtCacheBytesTotal, prometheus.CounterValue, stats.BytesReadInto, "read")
+	ch <- prometheus.MustNewConstMetric(wtCacheBytesTotal, prometheus.CounterValue, stats.BytesWrittenFrom, "written")
+	ch <- prometheus.MustNewConstMetric(wtCacheEvictedTotal, prometheus.CounterValue, stats.EvictedModified, "modified")
+	ch <- prometheus.MustNewConstMetric(wtCacheEvictedTotal, prometheus.CounterValue, stats.EvictedUnmodified, "unmodified")
 	wtCachePages.WithLabelValues("total").Set(stats.PagesTotal)
 	wtCachePages.WithLabelValues("dirty").Set(stats.PagesDirty)
 	wtCacheBytes.WithLabelValues("total").Set(stats.BytesTotal)
@@ -212,8 +190,8 @@ func (stats *WTCacheStats) Export(ch chan<- prometheus.Metric) {
 }
 
 func (stats *WTCacheStats) Describe(ch chan<- *prometheus.Desc) {
-	wtCachePagesTotal.Describe(ch)
-	wtCacheEvictedTotal.Describe(ch)
+	ch <- wtCachePagesTotal
+	ch <- wtCacheEvictedTotal
 	wtCachePages.Describe(ch)
 	wtCacheBytes.Describe(ch)
 	wtCacheMaxBytes.Describe(ch)
@@ -240,25 +218,25 @@ type WTLogStats struct {
 }
 
 func (stats *WTLogStats) Export(ch chan<- prometheus.Metric) {
-	wtLogRecordsTotal.WithLabelValues("compressed").Set(stats.RecordsCompressed)
-	wtLogRecordsTotal.WithLabelValues("uncompressed").Set(stats.RecordsUncompressed)
-        wtLogBytesTotal.WithLabelValues("payload").Set(stats.BytesPayloadData)
-        wtLogBytesTotal.WithLabelValues("written").Set(stats.BytesWritten)
-        wtLogOperationsTotal.WithLabelValues("read").Set(stats.LogReads)
-        wtLogOperationsTotal.WithLabelValues("write").Set(stats.LogWrites)
-        wtLogOperationsTotal.WithLabelValues("scan").Set(stats.LogScans)
-        wtLogOperationsTotal.WithLabelValues("scan_double").Set(stats.LogScansDouble)
-        wtLogOperationsTotal.WithLabelValues("sync").Set(stats.LogSyncs)
-        wtLogOperationsTotal.WithLabelValues("sync_dir").Set(stats.LogSyncDirs)
-        wtLogOperationsTotal.WithLabelValues("flush").Set(stats.LogFlushes)
-	wtLogRecordsScannedTotal.Set(stats.RecordsProcessedLogScan)
+	ch <- prometheus.MustNewConstMetric(wtLogRecordsTotal, prometheus.CounterValue, stats.RecordsCompressed, "compressed")
+	ch <- prometheus.MustNewConstMetric(wtLogRecordsTotal, prometheus.CounterValue, stats.RecordsUncompressed, "uncompressed")
+  ch <- prometheus.MustNewConstMetric(wtLogBytesTotal, prometheus.CounterValue, stats.BytesPayloadData, "payload")
+  ch <- prometheus.MustNewConstMetric(wtLogBytesTotal, prometheus.CounterValue, stats.BytesWritten, "written")
+  ch <- prometheus.MustNewConstMetric(wtLogOperationsTotal, prometheus.CounterValue, stats.LogReads, "read")
+  ch <- prometheus.MustNewConstMetric(wtLogOperationsTotal, prometheus.CounterValue, stats.LogWrites, "write")
+  ch <- prometheus.MustNewConstMetric(wtLogOperationsTotal, prometheus.CounterValue, stats.LogScans, "scan")
+  ch <- prometheus.MustNewConstMetric(wtLogOperationsTotal, prometheus.CounterValue, stats.LogScansDouble, "scan_double")
+  ch <- prometheus.MustNewConstMetric(wtLogOperationsTotal, prometheus.CounterValue, stats.LogSyncs, "sync")
+  ch <- prometheus.MustNewConstMetric(wtLogOperationsTotal, prometheus.CounterValue, stats.LogSyncDirs, "sync_dir")
+  ch <- prometheus.MustNewConstMetric(wtLogOperationsTotal, prometheus.CounterValue, stats.LogFlushes, "flush")
+	ch <- prometheus.MustNewConstMetric(wtLogRecordsScannedTotal, prometheus.CounterValue, stats.RecordsProcessedLogScan)
 }
 
 func (stats *WTLogStats) Describe(ch chan<- *prometheus.Desc) {
-	wtLogRecordsTotal.Describe(ch)
-	wtLogBytesTotal.Describe(ch)
-	wtLogOperationsTotal.Describe(ch)
-	wtLogRecordsScannedTotal.Describe(ch)
+	ch <- wtLogRecordsTotal
+	ch <- wtLogBytesTotal
+	ch <- wtLogOperationsTotal
+	ch <- wtLogRecordsScannedTotal
 }
 
 // session stats
@@ -292,19 +270,19 @@ type WTTransactionStats struct {
 }
 
 func (stats *WTTransactionStats) Export(ch chan<- prometheus.Metric) {
-	wtTransactionsTotal.WithLabelValues("begins").Set(stats.Begins)
-	wtTransactionsTotal.WithLabelValues("checkpoints").Set(stats.Checkpoints)
-	wtTransactionsTotal.WithLabelValues("committed").Set(stats.Committed)
-	wtTransactionsTotal.WithLabelValues("rolledback").Set(stats.RolledBack)
+	ch <- prometheus.MustNewConstMetric(wtTransactionsTotal, prometheus.CounterValue, stats.Begins, "begins")
+	ch <- prometheus.MustNewConstMetric(wtTransactionsTotal, prometheus.CounterValue, stats.Checkpoints, "checkpoints")
+	ch <- prometheus.MustNewConstMetric(wtTransactionsTotal, prometheus.CounterValue, stats.Committed, "committed")
+	ch <- prometheus.MustNewConstMetric(wtTransactionsTotal, prometheus.CounterValue, stats.RolledBack, "rolledback")
 	wtTransactionsCheckpointMs.WithLabelValues("min").Set(stats.CheckpointMinMs)
 	wtTransactionsCheckpointMs.WithLabelValues("max").Set(stats.CheckpointMaxMs)
-	wtTransactionsTotalCheckpointMs.Set(stats.CheckpointTotalMs)
+	ch <- prometheus.MustNewConstMetric(wtTransactionsTotalCheckpointMs, prometheus.CounterValue, stats.CheckpointTotalMs)
 	wtTransactionsCheckpointsRunning.Set(stats.CheckpointsRunning)
 }
 
 func (stats *WTTransactionStats) Describe(ch chan<- *prometheus.Desc) {
-	wtTransactionsTotal.Describe(ch)
-	wtTransactionsTotalCheckpointMs.Describe(ch)
+	ch <- wtTransactionsTotal
+	ch <- wtTransactionsTotalCheckpointMs
 	wtTransactionsCheckpointMs.Describe(ch)
 	wtTransactionsCheckpointsRunning.Describe(ch)
 }
@@ -387,26 +365,13 @@ func (stats *WiredTigerStats) Export(ch chan<- prometheus.Metric) {
 		stats.ConcurrentTransactions.Export(ch)
 	}
 
-	wtBlockManagerBlocksTotal.Collect(ch)
-	wtBlockManagerBytesTotal.Collect(ch)
-
-	wtCachePagesTotal.Collect(ch)
-	wtCacheBytesTotal.Collect(ch)
-	wtCacheEvictedTotal.Collect(ch)
 	wtCachePages.Collect(ch)
 	wtCacheBytes.Collect(ch)
 	wtCacheMaxBytes.Collect(ch)
 	wtCachePercentOverhead.Collect(ch)
 
-	wtTransactionsTotal.Collect(ch)
-	wtTransactionsTotalCheckpointMs.Collect(ch)
 	wtTransactionsCheckpointMs.Collect(ch)
 	wtTransactionsCheckpointsRunning.Collect(ch)
-
-	wtLogRecordsTotal.Collect(ch)
-	wtLogBytesTotal.Collect(ch)
-	wtLogOperationsTotal.Collect(ch)
-	wtLogRecordsScannedTotal.Collect(ch)
 
 	wtOpenCursors.Collect(ch)
 	wtOpenSessions.Collect(ch)

--- a/collector/mongos/asserts.go
+++ b/collector/mongos/asserts.go
@@ -5,11 +5,10 @@ import (
 )
 
 var (
-	assertsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "asserts_total",
-		Help:      "The asserts document reports the number of asserts on the database. While assert errors are typically uncommon, if there are non-zero values for the asserts, you should check the log file for the mongod process for more information. In many cases these errors are trivial, but are worth investigating.",
-	}, []string{"type"})
+	assertsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "asserts_total"),
+		"The asserts document reports the number of asserts on the database. While assert errors are typically uncommon, if there are non-zero values for the asserts, you should check the log file for the mongod process for more information. In many cases these errors are trivial, but are worth investigating.",
+		[]string{"type"}, nil)
 )
 
 // AssertsStats has the assets metrics
@@ -23,15 +22,14 @@ type AssertsStats struct {
 
 // Export exports the metrics to prometheus.
 func (asserts *AssertsStats) Export(ch chan<- prometheus.Metric) {
-	assertsTotal.WithLabelValues("regular").Set(asserts.Regular)
-	assertsTotal.WithLabelValues("warning").Set(asserts.Warning)
-	assertsTotal.WithLabelValues("msg").Set(asserts.Msg)
-	assertsTotal.WithLabelValues("user").Set(asserts.User)
-	assertsTotal.WithLabelValues("rollovers").Set(asserts.Rollovers)
-	assertsTotal.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.Regular, "regular")
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.Warning, "warning")
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.Msg, "msg")
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.User, "user")
+	ch <- prometheus.MustNewConstMetric(assertsTotal, prometheus.CounterValue, asserts.Rollovers, "rollovers")
 }
 
 // Describe describes the metrics for prometheus
 func (asserts *AssertsStats) Describe(ch chan<- *prometheus.Desc) {
-	assertsTotal.Describe(ch)
+	ch <- assertsTotal
 }

--- a/collector/mongos/connections.go
+++ b/collector/mongos/connections.go
@@ -12,12 +12,10 @@ var (
 	}, []string{"state"})
 )
 var (
-	connectionsMetricsCreatedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "connections_metrics",
-		Name:      "created_total",
-		Help:      "totalCreated provides a count of all incoming connections created to the server. This number includes connections that have since closed",
-	})
+	connectionsMetricsCreatedTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "connections_metrics", "created_total"),
+		"totalCreated provides a count of all incoming connections created to the server. This number includes connections that have since closed",
+		nil, nil)
 )
 
 // ConnectionStats are connections metrics
@@ -32,13 +30,11 @@ func (connectionStats *ConnectionStats) Export(ch chan<- prometheus.Metric) {
 	connections.WithLabelValues("current").Set(connectionStats.Current)
 	connections.WithLabelValues("available").Set(connectionStats.Available)
 	connections.Collect(ch)
-
-	connectionsMetricsCreatedTotal.Set(connectionStats.TotalCreated)
-	connectionsMetricsCreatedTotal.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(connectionsMetricsCreatedTotal, prometheus.CounterValue, connectionStats.TotalCreated)
 }
 
 // Describe describes the metrics for prometheus
 func (connectionStats *ConnectionStats) Describe(ch chan<- *prometheus.Desc) {
 	connections.Describe(ch)
-	connectionsMetricsCreatedTotal.Describe(ch)
+	ch <- connectionsMetricsCreatedTotal
 }

--- a/collector/mongos/network.go
+++ b/collector/mongos/network.go
@@ -5,19 +5,16 @@ import (
 )
 
 var (
-	networkBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "network_bytes_total",
-		Help:      "The network data structure contains data regarding MongoDB’s network use",
-	}, []string{"state"})
+	networkBytesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "network_bytes_total"),
+		"The network data structure contains data regarding MongoDB’s network use",
+	  []string{"state"}, nil)
 )
 var (
-	networkMetricsNumRequestsTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "network_metrics",
-		Name:      "num_requests_total",
-		Help:      "The numRequests field is a counter of the total number of distinct requests that the server has received. Use this value to provide context for the bytesIn and bytesOut values to ensure that MongoDB’s network utilization is consistent with expectations and application use",
-	})
+	networkMetricsNumRequestsTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "network_metrics", "num_requests_total"),
+		"The numRequests field is a counter of the total number of distinct requests that the server has received. Use this value to provide context for the bytesIn and bytesOut values to ensure that MongoDB’s network utilization is consistent with expectations and application use",
+		nil, nil)
 )
 
 //NetworkStats network stats
@@ -29,17 +26,14 @@ type NetworkStats struct {
 
 // Export exports the data to prometheus
 func (networkStats *NetworkStats) Export(ch chan<- prometheus.Metric) {
-	networkBytesTotal.WithLabelValues("in_bytes").Set(networkStats.BytesIn)
-	networkBytesTotal.WithLabelValues("out_bytes").Set(networkStats.BytesOut)
+	ch <- prometheus.MustNewConstMetric(networkBytesTotal, prometheus.CounterValue, networkStats.BytesIn, "in_bytes")
+	ch <- prometheus.MustNewConstMetric(networkBytesTotal, prometheus.CounterValue, networkStats.BytesOut, "out_bytes")
 
-	networkMetricsNumRequestsTotal.Set(networkStats.NumRequests)
-
-	networkMetricsNumRequestsTotal.Collect(ch)
-	networkBytesTotal.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(networkMetricsNumRequestsTotal, prometheus.CounterValue, networkStats.NumRequests)
 }
 
 // Describe describes the metrics for prometheus
 func (networkStats *NetworkStats) Describe(ch chan<- *prometheus.Desc) {
-	networkMetricsNumRequestsTotal.Describe(ch)
-	networkBytesTotal.Describe(ch)
+	ch <- networkMetricsNumRequestsTotal
+	ch <- networkBytesTotal
 }

--- a/collector/mongos/op_counters.go
+++ b/collector/mongos/op_counters.go
@@ -5,18 +5,16 @@ import (
 )
 
 var (
-	opCountersTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "op_counters_total",
-		Help:      "The opcounters data structure provides an overview of database operations by type and makes it possible to analyze the load on the database in more granular manner. These numbers will grow over time and in response to database use. Analyze these values over time to track database utilization",
-	}, []string{"type"})
+	opCountersTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "op_counters_total"),
+		"The opcounters data structure provides an overview of database operations by type and makes it possible to analyze the load on the database in more granular manner. These numbers will grow over time and in response to database use. Analyze these values over time to track database utilization",
+	  []string{"type"}, nil)
 )
 var (
-	opCountersReplTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "op_counters_repl_total",
-		Help:      "The opcountersRepl data structure, similar to the opcounters data structure, provides an overview of database replication operations by type and makes it possible to analyze the load on the replica in more granular manner. These values only appear when the current host has replication enabled",
-	}, []string{"type"})
+	opCountersReplTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "op_counters_repl_total"),
+		"The opcountersRepl data structure, similar to the opcounters data structure, provides an overview of database replication operations by type and makes it possible to analyze the load on the replica in more granular manner. These values only appear when the current host has replication enabled",
+	  []string{"type"}, nil)
 )
 
 // OpcountersStats opcounters stats
@@ -31,19 +29,17 @@ type OpcountersStats struct {
 
 // Export exports the data to prometheus.
 func (opCounters *OpcountersStats) Export(ch chan<- prometheus.Metric) {
-	opCountersTotal.WithLabelValues("insert").Set(opCounters.Insert)
-	opCountersTotal.WithLabelValues("query").Set(opCounters.Query)
-	opCountersTotal.WithLabelValues("update").Set(opCounters.Update)
-	opCountersTotal.WithLabelValues("delete").Set(opCounters.Delete)
-	opCountersTotal.WithLabelValues("getmore").Set(opCounters.GetMore)
-	opCountersTotal.WithLabelValues("command").Set(opCounters.Command)
-
-	opCountersTotal.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Insert, "insert")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Query, "query")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Update, "update")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Delete, "delete")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.GetMore, "getmore")
+	ch <- prometheus.MustNewConstMetric(opCountersTotal, prometheus.CounterValue, opCounters.Command, "command")
 }
 
 // Describe describes the metrics for prometheus
 func (opCounters *OpcountersStats) Describe(ch chan<- *prometheus.Desc) {
-	opCountersTotal.Describe(ch)
+	ch <- opCountersTotal
 }
 
 // OpcountersReplStats opcounters stats
@@ -58,17 +54,15 @@ type OpcountersReplStats struct {
 
 // Export exports the data to prometheus.
 func (opCounters *OpcountersReplStats) Export(ch chan<- prometheus.Metric) {
-	opCountersReplTotal.WithLabelValues("insert").Set(opCounters.Insert)
-	opCountersReplTotal.WithLabelValues("query").Set(opCounters.Query)
-	opCountersReplTotal.WithLabelValues("update").Set(opCounters.Update)
-	opCountersReplTotal.WithLabelValues("delete").Set(opCounters.Delete)
-	opCountersReplTotal.WithLabelValues("getmore").Set(opCounters.GetMore)
-	opCountersReplTotal.WithLabelValues("command").Set(opCounters.Command)
-
-	opCountersReplTotal.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Insert, "insert")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Query, "query")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Update, "update")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Delete, "delete")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.GetMore, "getmore")
+	ch <- prometheus.MustNewConstMetric(opCountersReplTotal, prometheus.CounterValue, opCounters.Command, "command")
 }
 
 // Describe describes the metrics for prometheus
 func (opCounters *OpcountersReplStats) Describe(ch chan<- *prometheus.Desc) {
-	opCountersReplTotal.Describe(ch)
+	ch <- opCountersReplTotal
 }

--- a/collector/mongos/server_status.go
+++ b/collector/mongos/server_status.go
@@ -10,24 +10,18 @@ import (
 )
 
 var (
-	instanceUptimeSeconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "instance",
-		Name:      "uptime_seconds",
-		Help:      "The value of the uptime field corresponds to the number of seconds that the mongos or mongod process has been active.",
-	})
-	instanceUptimeEstimateSeconds = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "instance",
-		Name:      "uptime_estimate_seconds",
-		Help:      "uptimeEstimate provides the uptime as calculated from MongoDB's internal course-grained time keeping system.",
-	})
-	instanceLocalTime = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "instance",
-		Name:      "local_time",
-		Help:      "The localTime value is the current time, according to the server, in UTC specified in an ISODate format.",
-	})
+	instanceUptimeSeconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "instance", "uptime_seconds"),
+		"The value of the uptime field corresponds to the number of seconds that the mongos or mongod process has been active.",
+		nil, nil)
+	instanceUptimeEstimateSeconds = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "instance", "uptime_estimate_seconds"),
+		"uptimeEstimate provides the uptime as calculated from MongoDB's internal course-grained time keeping system.",
+		nil, nil)
+	instanceLocalTime = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "instance", "local_time"),
+		"The localTime value is the current time, according to the server, in UTC specified in an ISODate format.",
+	  nil, nil)
 )
 
 // ServerStatus keeps the data returned by the serverStatus() method.
@@ -53,12 +47,9 @@ type ServerStatus struct {
 
 // Export exports the server status to be consumed by prometheus.
 func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
-	instanceUptimeSeconds.Set(status.Uptime)
-	instanceUptimeEstimateSeconds.Set(status.Uptime)
-	instanceLocalTime.Set(float64(status.LocalTime.Unix()))
-	instanceUptimeSeconds.Collect(ch)
-	instanceUptimeEstimateSeconds.Collect(ch)
-	instanceLocalTime.Collect(ch)
+	ch <- prometheus.MustNewConstMetric(instanceUptimeSeconds, prometheus.CounterValue, status.Uptime)
+	ch <- prometheus.MustNewConstMetric(instanceUptimeEstimateSeconds, prometheus.CounterValue, status.Uptime)
+	ch <- prometheus.MustNewConstMetric(instanceLocalTime, prometheus.CounterValue, float64(status.LocalTime.Unix()))
 
 	if status.Asserts != nil {
 		status.Asserts.Export(ch)
@@ -88,9 +79,9 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 
 // Describe describes the server status for prometheus.
 func (status *ServerStatus) Describe(ch chan<- *prometheus.Desc) {
-	instanceUptimeSeconds.Describe(ch)
-	instanceUptimeEstimateSeconds.Describe(ch)
-	instanceLocalTime.Describe(ch)
+	ch <- instanceUptimeSeconds
+	ch <- instanceUptimeEstimateSeconds
+	ch <- instanceLocalTime
 
 	if status.Asserts != nil {
 		status.Asserts.Describe(ch)


### PR DESCRIPTION
This pull request works again with the latest version of prometheus golang-client where in [this commit](https://github.com/prometheus/client_golang/commit/2fee50beaa152342e8347c41edf2202c3bd5f858) the counter.Set method was removed. 