### PR TITLE
Return 'mmapv1' as storage engine if db.serverStatus().storageEngine doesn't exist (added in 3.0)

### DIFF
--- a/collector/mongod/server_status.go
+++ b/collector/mongod/server_status.go
@@ -128,7 +128,8 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 		status.WiredTiger.Export(ch)
 	}
 
-	// if db.serverStatus.storageEngine does not exists, you're on < 3.0, and thus mmapv1
+	// If db.serverStatus().storageEngine does not exists, you're on < 3.0, and thus mmapv1
+	// https://docs.mongodb.com/v3.0/reference/command/serverStatus/#storageengine
 	if status.StorageEngine == nil {
 		status.StorageEngine = &StorageEngineStats{
 			Name: "mmapv1",

--- a/collector/mongod/server_status.go
+++ b/collector/mongod/server_status.go
@@ -61,10 +61,10 @@ type ServerStatus struct {
 
 	Cursors *Cursors `bson:"cursors"`
 
-	StorageEngine	*StorageEngineStats	`bson:"storageEngine"`
-	InMemory	*WiredTigerStats	`bson:"inMemory"`
-	RocksDb		*RocksDbStats		`bson:"rocksdb"`
-	WiredTiger	*WiredTigerStats	`bson:"wiredTiger"`
+	StorageEngine *StorageEngineStats `bson:"storageEngine"`
+	InMemory      *WiredTigerStats    `bson:"inMemory"`
+	RocksDb       *RocksDbStats       `bson:"rocksdb"`
+	WiredTiger    *WiredTigerStats    `bson:"wiredTiger"`
 }
 
 // Export exports the server status to be consumed by prometheus.
@@ -118,9 +118,6 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 	if status.Cursors != nil {
 		status.Cursors.Export(ch)
 	}
-	if status.StorageEngine != nil {
-		status.StorageEngine.Export(ch)
-	}
 	if status.InMemory != nil {
 		status.InMemory.Export(ch)
 	}
@@ -130,6 +127,14 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 	if status.WiredTiger != nil {
 		status.WiredTiger.Export(ch)
 	}
+
+	// if db.serverStatus.storageEngine does not exists, you're on < 3.0, and thus mmapv1
+	if status.StorageEngine == nil {
+		status.StorageEngine = &StorageEngineStats{
+			Name: "mmapv1",
+		}
+	}
+	status.StorageEngine.Export(ch)
 }
 
 // Describe describes the server status for prometheus.

--- a/collector/mongod/server_status.go
+++ b/collector/mongod/server_status.go
@@ -128,14 +128,16 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 		status.WiredTiger.Export(ch)
 	}
 
-	// If db.serverStatus().storageEngine does not exists, you're on < 3.0, and thus mmapv1
+	// If db.serverStatus().storageEngine does not exist (3.0+ only) and status.BackgroundFlushing does (MMAPv1 only), default to mmapv1
 	// https://docs.mongodb.com/v3.0/reference/command/serverStatus/#storageengine
-	if status.StorageEngine == nil {
+	if status.StorageEngine == nil && status.BackgroundFlushing != nil {
 		status.StorageEngine = &StorageEngineStats{
 			Name: "mmapv1",
 		}
 	}
-	status.StorageEngine.Export(ch)
+	if status.StorageEngine != nil {
+		status.StorageEngine.Export(ch)
+	}
 }
 
 // Describe describes the server status for prometheus.

--- a/collector/mongod/storage_engine.go
+++ b/collector/mongod/storage_engine.go
@@ -14,7 +14,7 @@ var (
 
 // StorageEngineStats
 type StorageEngineStats struct {
-	Name	string	`bson:"name"`
+	Name string `bson:"name"`
 }
 
 // Export exports the data to prometheus.


### PR DESCRIPTION
Our 'mongodb_mongod_storage_engine' metric seems to break on MongoDB 2.x because the db.serverStatus().storageEngine document did not exist in this version.

This changes the exporter to return 'mmapv1' as the storage engine type if db.serverStatus().storageEngine (3.0+ only) does not exist and/but db.serverStatus().backgroundFlushing does exist (only shows on MMAPv1 instances). The 2nd condition is to avoid TokuMX showing as MMAPv1, mostly.

EDIT: My golang IDE fixed some whitespace alignment on 2 x structs, no logic changed to those lines.