### PR TITLE
Export WiredTiger Cache leaf page and internal page tracked bytes

### DIFF
--- a/collector/mongod/wiredtiger.go
+++ b/collector/mongod/wiredtiger.go
@@ -1,168 +1,168 @@
 package collector_mongod
 
-import(
+import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
 	wtBlockManagerBlocksTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_blockmanager",
-		Name:		"blocks_total",
-		Help:		"The total number of blocks read by the WiredTiger BlockManager",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_blockmanager",
+		Name:      "blocks_total",
+		Help:      "The total number of blocks read by the WiredTiger BlockManager",
 	}, []string{"type"})
 	wtBlockManagerBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_blockmanager",
-		Name:		"bytes_total",
-		Help:		"The total number of bytes read by the WiredTiger BlockManager",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_blockmanager",
+		Name:      "bytes_total",
+		Help:      "The total number of bytes read by the WiredTiger BlockManager",
 	}, []string{"type"})
 )
 
 var (
 	wtCachePages = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"pages",
-		Help:		"The current number of pages in the WiredTiger Cache",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_cache",
+		Name:      "pages",
+		Help:      "The current number of pages in the WiredTiger Cache",
 	}, []string{"type"})
 	wtCachePagesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"pages_total",
-		Help:		"The total number of pages read into/from the WiredTiger Cache",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_cache",
+		Name:      "pages_total",
+		Help:      "The total number of pages read into/from the WiredTiger Cache",
 	}, []string{"type"})
 	wtCacheBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"bytes",
-		Help:		"The current size of data in the WiredTiger Cache in bytes",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_cache",
+		Name:      "bytes",
+		Help:      "The current size of data in the WiredTiger Cache in bytes",
 	}, []string{"type"})
 	wtCacheMaxBytes = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"max_bytes",
-		Help:		"The maximum size of data in the WiredTiger Cache in bytes",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_cache",
+		Name:      "max_bytes",
+		Help:      "The maximum size of data in the WiredTiger Cache in bytes",
 	})
 	wtCacheBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"bytes_total",
-		Help:		"The total number of bytes read into/from the WiredTiger Cache",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_cache",
+		Name:      "bytes_total",
+		Help:      "The total number of bytes read into/from the WiredTiger Cache",
 	}, []string{"type"})
 	wtCacheEvictedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"evicted_total",
-		Help:		"The total number of pages evicted from the WiredTiger Cache",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_cache",
+		Name:      "evicted_total",
+		Help:      "The total number of pages evicted from the WiredTiger Cache",
 	}, []string{"type"})
 	wtCachePercentOverhead = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_cache",
-		Name:		"overhead_percent",
-		Help:		"The percentage overhead of the WiredTiger Cache",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_cache",
+		Name:      "overhead_percent",
+		Help:      "The percentage overhead of the WiredTiger Cache",
 	})
 )
 
-var(
+var (
 	wtTransactionsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_transactions",
-		Name:		"total",
-		Help:		"The total number of transactions WiredTiger has handled",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_transactions",
+		Name:      "total",
+		Help:      "The total number of transactions WiredTiger has handled",
 	}, []string{"type"})
 	wtTransactionsTotalCheckpointMs = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_transactions",
-		Name:		"checkpoint_milliseconds_total",
-		Help:		"The total time in milliseconds transactions have checkpointed in WiredTiger",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_transactions",
+		Name:      "checkpoint_milliseconds_total",
+		Help:      "The total time in milliseconds transactions have checkpointed in WiredTiger",
 	})
 	wtTransactionsCheckpointMs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_transactions",
-		Name:		"checkpoint_milliseconds",
-		Help:		"The time in milliseconds transactions have checkpointed in WiredTiger",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_transactions",
+		Name:      "checkpoint_milliseconds",
+		Help:      "The time in milliseconds transactions have checkpointed in WiredTiger",
 	}, []string{"type"})
 	wtTransactionsCheckpointsRunning = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_transactions",
-		Name:		"running_checkpoints",
-		Help:		"The number of currently running checkpoints in WiredTiger",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_transactions",
+		Name:      "running_checkpoints",
+		Help:      "The number of currently running checkpoints in WiredTiger",
 	})
 )
 
-var(
+var (
 	wtLogRecordsScannedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_log",
-                Name:           "records_scanned_total",
-                Help:           "The total number of records scanned by log scan in the WiredTiger log",
-        })
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_log",
+		Name:      "records_scanned_total",
+		Help:      "The total number of records scanned by log scan in the WiredTiger log",
+	})
 	wtLogRecordsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_log",
-                Name:           "records_total",
-                Help:           "The total number of compressed/uncompressed records written to the WiredTiger log",
-        }, []string{"type"})
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_log",
+		Name:      "records_total",
+		Help:      "The total number of compressed/uncompressed records written to the WiredTiger log",
+	}, []string{"type"})
 	wtLogBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_log",
-                Name:           "bytes_total",
-                Help:           "The total number of bytes written to the WiredTiger log",
-        }, []string{"type"})
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_log",
+		Name:      "bytes_total",
+		Help:      "The total number of bytes written to the WiredTiger log",
+	}, []string{"type"})
 	wtLogOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_log",
-                Name:           "operations_total",
-                Help:           "The total number of WiredTiger log operations",
-        }, []string{"type"})
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_log",
+		Name:      "operations_total",
+		Help:      "The total number of WiredTiger log operations",
+	}, []string{"type"})
 )
 
-var(
+var (
 	wtOpenCursors = prometheus.NewGauge(prometheus.GaugeOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_session",
-                Name:           "open_cursors_total",
-                Help:           "The total number of cursors opened in WiredTiger",
-        })
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_session",
+		Name:      "open_cursors_total",
+		Help:      "The total number of cursors opened in WiredTiger",
+	})
 	wtOpenSessions = prometheus.NewGauge(prometheus.GaugeOpts{
-                Namespace:      Namespace,
-                Subsystem:      "wiredtiger_session",
-                Name:           "open_sessions_total",
-                Help:           "The total number of sessions opened in WiredTiger",
-        })
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_session",
+		Name:      "open_sessions_total",
+		Help:      "The total number of sessions opened in WiredTiger",
+	})
 )
 
-var(
+var (
 	wtConcurrentTransactionsOut = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:      Namespace,
-		Subsystem:      "wiredtiger_concurrent_transactions",
-		Name:	   	"out_tickets",
-		Help:	   	"The number of tickets that are currently in use (out) in WiredTiger",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_concurrent_transactions",
+		Name:      "out_tickets",
+		Help:      "The number of tickets that are currently in use (out) in WiredTiger",
 	}, []string{"type"})
 	wtConcurrentTransactionsAvailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_concurrent_transactions",
-		Name:		"available_tickets",
-		Help:		"The number of tickets that are available in WiredTiger",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_concurrent_transactions",
+		Name:      "available_tickets",
+		Help:      "The number of tickets that are available in WiredTiger",
 	}, []string{"type"})
 	wtConcurrentTransactionsTotalTickets = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:	Namespace,
-		Subsystem:	"wiredtiger_concurrent_transactions",
-		Name:		"total_tickets",
-		Help:		"The total number of tickets that are available in WiredTiger",
+		Namespace: Namespace,
+		Subsystem: "wiredtiger_concurrent_transactions",
+		Name:      "total_tickets",
+		Help:      "The total number of tickets that are available in WiredTiger",
 	}, []string{"type"})
 )
 
 // blockmanager stats
 type WTBlockManagerStats struct {
-	MappedBytesRead			float64	`bson:"mapped bytes read"`
-	BytesRead			float64 `bson:"bytes read"`
-	BytesWritten			float64 `bson:"bytes written"`
-	MappedBlocksRead		float64 `bson:"mapped blocks read"`
-	BlocksPreLoaded			float64 `bson:"blocks pre-loaded"`
-	BlocksRead			float64 `bson:"blocks read"`
-	BlocksWritten			float64 `bson:"blocks written"`
+	MappedBytesRead  float64 `bson:"mapped bytes read"`
+	BytesRead        float64 `bson:"bytes read"`
+	BytesWritten     float64 `bson:"bytes written"`
+	MappedBlocksRead float64 `bson:"mapped blocks read"`
+	BlocksPreLoaded  float64 `bson:"blocks pre-loaded"`
+	BlocksRead       float64 `bson:"blocks read"`
+	BlocksWritten    float64 `bson:"blocks written"`
 }
 
 func (stats *WTBlockManagerStats) Export(ch chan<- prometheus.Metric) {
@@ -182,18 +182,20 @@ func (stats *WTBlockManagerStats) Describe(ch chan<- *prometheus.Desc) {
 
 // cache stats
 type WTCacheStats struct {
-	BytesTotal			float64 `bson:"bytes currently in the cache"`
-	BytesDirty			float64	`bson:"tracked dirty bytes in the cache"`
-	MaxBytes			float64	`bson:"maximum bytes configured"`
-	BytesReadInto			float64 `bson:"bytes read into cache"`
-	BytesWrittenFrom		float64 `bson:"bytes written from cache"`
-	EvictedUnmodified		float64 `bson:"unmodified pages evicted"`
-	EvictedModified			float64 `bson:"modified pages evicted"`
-	PercentOverhead			float64 `bson:"percentage overhead"`
-	PagesTotal			float64 `bson:"pages currently held in the cache"`
-	PagesReadInto			float64 `bson:"pages read into cache"`
-	PagesWrittenFrom		float64 `bson:"pages written from cache"`
-	PagesDirty			float64 `bson:"tracked dirty pages in the cache"`
+	BytesTotal         float64 `bson:"bytes currently in the cache"`
+	BytesDirty         float64 `bson:"tracked dirty bytes in the cache"`
+	BytesInternalPages float64 `bson:"tracked bytes belonging to internal pages in the cache"`
+	BytesLeafPages     float64 `bson:"tracked bytes belonging to leaf pages in the cache"`
+	MaxBytes           float64 `bson:"maximum bytes configured"`
+	BytesReadInto      float64 `bson:"bytes read into cache"`
+	BytesWrittenFrom   float64 `bson:"bytes written from cache"`
+	EvictedUnmodified  float64 `bson:"unmodified pages evicted"`
+	EvictedModified    float64 `bson:"modified pages evicted"`
+	PercentOverhead    float64 `bson:"percentage overhead"`
+	PagesTotal         float64 `bson:"pages currently held in the cache"`
+	PagesReadInto      float64 `bson:"pages read into cache"`
+	PagesWrittenFrom   float64 `bson:"pages written from cache"`
+	PagesDirty         float64 `bson:"tracked dirty pages in the cache"`
 }
 
 func (stats *WTCacheStats) Export(ch chan<- prometheus.Metric) {
@@ -207,6 +209,8 @@ func (stats *WTCacheStats) Export(ch chan<- prometheus.Metric) {
 	wtCachePages.WithLabelValues("dirty").Set(stats.PagesDirty)
 	wtCacheBytes.WithLabelValues("total").Set(stats.BytesTotal)
 	wtCacheBytes.WithLabelValues("dirty").Set(stats.BytesDirty)
+	wtCacheBytes.WithLabelValues("internal_pages").Set(stats.BytesInternalPages)
+	wtCacheBytes.WithLabelValues("leaf_pages").Set(stats.BytesLeafPages)
 	wtCacheMaxBytes.Set(stats.MaxBytes)
 	wtCachePercentOverhead.Set(stats.PercentOverhead)
 }
@@ -222,35 +226,35 @@ func (stats *WTCacheStats) Describe(ch chan<- *prometheus.Desc) {
 
 // log stats
 type WTLogStats struct {
-	TotalBufferSize			float64 `bson:"total log buffer size"`
-	TotalSizeCompressed		float64 `bson:"total size of compressed records"`
-	BytesPayloadData		float64 `bson:"log bytes of payload data"`
-	BytesWritten			float64 `bson:"log bytes written"`
-	RecordsUncompressed		float64 `bson:"log records not compressed"`
-	RecordsCompressed		float64 `bson:"log records compressed"`
-	RecordsProcessedLogScan		float64 `bson:"records processed by log scan"`
-	MaxLogSize			float64 `bson:"maximum log file size"`
-	LogFlushes			float64 `bson:"log flush operations"`
-	LogReads			float64 `bson:"log read operations"`
-	LogScansDouble			float64 `bson:"log scan records requiring two reads"`
-	LogScans			float64 `bson:"log scan operations"`
-	LogSyncs			float64 `bson:"log sync operations"`
-	LogSyncDirs			float64 `bson:"log sync_dir operations"`
-	LogWrites			float64 `bson:"log write operations"`
+	TotalBufferSize         float64 `bson:"total log buffer size"`
+	TotalSizeCompressed     float64 `bson:"total size of compressed records"`
+	BytesPayloadData        float64 `bson:"log bytes of payload data"`
+	BytesWritten            float64 `bson:"log bytes written"`
+	RecordsUncompressed     float64 `bson:"log records not compressed"`
+	RecordsCompressed       float64 `bson:"log records compressed"`
+	RecordsProcessedLogScan float64 `bson:"records processed by log scan"`
+	MaxLogSize              float64 `bson:"maximum log file size"`
+	LogFlushes              float64 `bson:"log flush operations"`
+	LogReads                float64 `bson:"log read operations"`
+	LogScansDouble          float64 `bson:"log scan records requiring two reads"`
+	LogScans                float64 `bson:"log scan operations"`
+	LogSyncs                float64 `bson:"log sync operations"`
+	LogSyncDirs             float64 `bson:"log sync_dir operations"`
+	LogWrites               float64 `bson:"log write operations"`
 }
 
 func (stats *WTLogStats) Export(ch chan<- prometheus.Metric) {
 	wtLogRecordsTotal.WithLabelValues("compressed").Set(stats.RecordsCompressed)
 	wtLogRecordsTotal.WithLabelValues("uncompressed").Set(stats.RecordsUncompressed)
-        wtLogBytesTotal.WithLabelValues("payload").Set(stats.BytesPayloadData)
-        wtLogBytesTotal.WithLabelValues("written").Set(stats.BytesWritten)
-        wtLogOperationsTotal.WithLabelValues("read").Set(stats.LogReads)
-        wtLogOperationsTotal.WithLabelValues("write").Set(stats.LogWrites)
-        wtLogOperationsTotal.WithLabelValues("scan").Set(stats.LogScans)
-        wtLogOperationsTotal.WithLabelValues("scan_double").Set(stats.LogScansDouble)
-        wtLogOperationsTotal.WithLabelValues("sync").Set(stats.LogSyncs)
-        wtLogOperationsTotal.WithLabelValues("sync_dir").Set(stats.LogSyncDirs)
-        wtLogOperationsTotal.WithLabelValues("flush").Set(stats.LogFlushes)
+	wtLogBytesTotal.WithLabelValues("payload").Set(stats.BytesPayloadData)
+	wtLogBytesTotal.WithLabelValues("written").Set(stats.BytesWritten)
+	wtLogOperationsTotal.WithLabelValues("read").Set(stats.LogReads)
+	wtLogOperationsTotal.WithLabelValues("write").Set(stats.LogWrites)
+	wtLogOperationsTotal.WithLabelValues("scan").Set(stats.LogScans)
+	wtLogOperationsTotal.WithLabelValues("scan_double").Set(stats.LogScansDouble)
+	wtLogOperationsTotal.WithLabelValues("sync").Set(stats.LogSyncs)
+	wtLogOperationsTotal.WithLabelValues("sync_dir").Set(stats.LogSyncDirs)
+	wtLogOperationsTotal.WithLabelValues("flush").Set(stats.LogFlushes)
 	wtLogRecordsScannedTotal.Set(stats.RecordsProcessedLogScan)
 }
 
@@ -263,8 +267,8 @@ func (stats *WTLogStats) Describe(ch chan<- *prometheus.Desc) {
 
 // session stats
 type WTSessionStats struct {
-	Cursors				float64	`bson:"open cursor count"`
-	Sessions			float64	`bson:"open session count"`
+	Cursors  float64 `bson:"open cursor count"`
+	Sessions float64 `bson:"open session count"`
 }
 
 func (stats *WTSessionStats) Export(ch chan<- prometheus.Metric) {
@@ -279,16 +283,16 @@ func (stats *WTSessionStats) Describe(ch chan<- *prometheus.Desc) {
 
 // transaction stats
 type WTTransactionStats struct {
-	Begins				float64 `bson:"transaction begins"`
-	Checkpoints			float64 `bson:"transaction checkpoints"`
-	CheckpointsRunning		float64 `bson:"transaction checkpoint currently running"`
-	CheckpointMaxMs			float64 `bson:"transaction checkpoint max time (msecs)"`
-	CheckpointMinMs			float64 `bson:"transaction checkpoint min time (msecs)"`
-	CheckpointLastMs		float64 `bson:"transaction checkpoint most recent time (msecs)"`
-	CheckpointTotalMs		float64 `bson:"transaction checkpoint total time (msecs)"`
-	Committed			float64 `bson:"transactions committed"`
-	CacheOverflowFailure		float64 `bson:"transaction failures due to cache overflow"`
-	RolledBack			float64 `bson:"transactions rolled back"`
+	Begins               float64 `bson:"transaction begins"`
+	Checkpoints          float64 `bson:"transaction checkpoints"`
+	CheckpointsRunning   float64 `bson:"transaction checkpoint currently running"`
+	CheckpointMaxMs      float64 `bson:"transaction checkpoint max time (msecs)"`
+	CheckpointMinMs      float64 `bson:"transaction checkpoint min time (msecs)"`
+	CheckpointLastMs     float64 `bson:"transaction checkpoint most recent time (msecs)"`
+	CheckpointTotalMs    float64 `bson:"transaction checkpoint total time (msecs)"`
+	Committed            float64 `bson:"transactions committed"`
+	CacheOverflowFailure float64 `bson:"transaction failures due to cache overflow"`
+	RolledBack           float64 `bson:"transactions rolled back"`
 }
 
 func (stats *WTTransactionStats) Export(ch chan<- prometheus.Metric) {
@@ -311,14 +315,14 @@ func (stats *WTTransactionStats) Describe(ch chan<- *prometheus.Desc) {
 
 // concurrenttransaction stats
 type WTConcurrentTransactionsTypeStats struct {
-	Out				float64 `bson:"out"`
-	Available			float64 `bson:"available"`
-	TotalTickets			float64 `bson:"totalTickets"`
+	Out          float64 `bson:"out"`
+	Available    float64 `bson:"available"`
+	TotalTickets float64 `bson:"totalTickets"`
 }
 
 type WTConcurrentTransactionsStats struct {
-	Write	*WTConcurrentTransactionsTypeStats	`bson:"read"`
-	Read	*WTConcurrentTransactionsTypeStats	`bson:"write"`
+	Write *WTConcurrentTransactionsTypeStats `bson:"read"`
+	Read  *WTConcurrentTransactionsTypeStats `bson:"write"`
 }
 
 func (stats *WTConcurrentTransactionsStats) Export(ch chan<- prometheus.Metric) {
@@ -338,12 +342,12 @@ func (stats *WTConcurrentTransactionsStats) Describe(ch chan<- *prometheus.Desc)
 
 // WiredTiger stats
 type WiredTigerStats struct {
-	BlockManager		*WTBlockManagerStats		`bson:"block-manager"`
-	Cache			*WTCacheStats			`bson:"cache"`
-	Log			*WTLogStats			`bson:"log"`
-	Session			*WTSessionStats			`bson:"session"`
-	Transaction		*WTTransactionStats		`bson:"transaction"`
-	ConcurrentTransactions	*WTConcurrentTransactionsStats	`bson:"concurrentTransactions"`
+	BlockManager           *WTBlockManagerStats           `bson:"block-manager"`
+	Cache                  *WTCacheStats                  `bson:"cache"`
+	Log                    *WTLogStats                    `bson:"log"`
+	Session                *WTSessionStats                `bson:"session"`
+	Transaction            *WTTransactionStats            `bson:"transaction"`
+	ConcurrentTransactions *WTConcurrentTransactionsStats `bson:"concurrentTransactions"`
 }
 
 func (stats *WiredTigerStats) Describe(ch chan<- *prometheus.Desc) {


### PR DESCRIPTION
As recommended by @denis-protyvenskyi for troubleshooting WT cache problems, I've added two more cache metrics to the exporter from WT's stats:

1. "tracked bytes belonging to internal pages in the cache"
2. "tracked bytes belonging to leaf pages in the cache"

The addition of these fields does not break the Grafana/PMM dashboard projects as each key from the vector I appended to is explicitly selected in our queries.

Note: my Golang IDE does auto whitespace fixing + Golint'ing, so that is why it looks like a lot has changed, but really the only changes are on lines 212-213 - adding two new keys to the metric vector.