### PR TITLE
Move mgo.Session deferred-Close() to after the if-nil check, redact username+password from log messages, reduce connect timeout

### DIFF
--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -61,7 +61,7 @@ func (exporter *MongodbCollector) Collect(ch chan<- prometheus.Metric) {
 			glog.Errorf("Problem gathering the mongo node type: %s", err)
 		}
 
-		glog.Infof("Connected to: %s (node type: %s, server version: %s)", exporter.Opts.URI, nodeType, serverVersion)
+		glog.Infof("Connected to: %s (node type: %s, server version: %s)", shared.RedactMongoUri(exporter.Opts.URI), nodeType, serverVersion)
 		switch {
 		case nodeType == "mongos":
 			exporter.collectMongos(mongoSess, ch)

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -38,11 +38,11 @@ func (exporter *MongodbCollector) Describe(ch chan<- *prometheus.Desc) {
 	glog.Info("Describing groups")
 	session := shared.MongoSession(exporter.Opts.URI)
 	if session != nil {
-		defer session.Close()
 		serverStatus := collector_mongos.GetServerStatus(session)
 		if serverStatus != nil {
 			serverStatus.Describe(ch)
 		}
+		session.Close()
 	}
 }
 

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -14,8 +15,9 @@ const (
 
 func MongoSession(uri string) *mgo.Session {
 	dialInfo, err := mgo.ParseURL(uri)
+	redactedUri := "mongodb://" + strings.Join(dialInfo.Addrs, ",")
 	if err != nil {
-		glog.Errorf("Cannot connect to server using url %s: %s", uri, err)
+		glog.Errorf("Cannot connect to server using url %s: %s", redactedUri, err)
 		return nil
 	}
 
@@ -24,7 +26,7 @@ func MongoSession(uri string) *mgo.Session {
 
 	session, err := mgo.DialWithInfo(dialInfo)
 	if err != nil {
-		glog.Errorf("Cannot connect to server using url %s: %s", uri, err)
+		glog.Errorf("Cannot connect to server using url %s: %s", redactedUri, err)
 		return nil
 	}
 	session.SetMode(mgo.Eventual, true)

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -14,12 +14,15 @@ const (
 )
 
 func RedactMongoUri(uri string) string {
-	dialInfo, err := mgo.ParseURL(uri)
-	if err != nil {
-		glog.Errorf("Cannot parse mongodb server url: %s", err)
-		return ""
+	if strings.HasPrefix(uri, "mongodb://") && strings.Contains(uri, "@") {
+		dialInfo, err := mgo.ParseURL(uri)
+		if err != nil {
+			glog.Errorf("Cannot parse mongodb server url: %s", err)
+			return ""
+		}
+		return "mongodb://" + strings.Join(dialInfo.Addrs, ",")
 	}
-	return "mongodb://" + strings.Join(dialInfo.Addrs, ",")
+	return uri
 }
 
 func MongoSession(uri string) *mgo.Session {

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -18,7 +18,7 @@ func RedactMongoUri(uri string) string {
 		dialInfo, err := mgo.ParseURL(uri)
 		if err != nil {
 			glog.Errorf("Cannot parse mongodb server url: %s", err)
-			return ""
+			return "unknown/error"
 		}
 		if dialInfo.Username != "" && dialInfo.Password != "" {
 			return "mongodb://****:****@" + strings.Join(dialInfo.Addrs, ",")

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -20,7 +20,9 @@ func RedactMongoUri(uri string) string {
 			glog.Errorf("Cannot parse mongodb server url: %s", err)
 			return ""
 		}
-		return "mongodb://" + strings.Join(dialInfo.Addrs, ",")
+		if dialInfo.Username != "" && dialInfo.Password != "" {
+			return "mongodb://****:****@" + strings.Join(dialInfo.Addrs, ",")
+		}
 	}
 	return uri
 }


### PR DESCRIPTION
When mongodb_exporter cannot connect to the database after starting, it crashes.

In collector/mongodb_collector.go we ask for a session and immediately call a 'defer session.Close()' on it. When the exporter cannot connect to the DB this means we call a .Close() on a nil, then the exporter crashes.

This fix moves the 'defer session.Close()' to be within the if-nil brackets so this never happens. This will resolve crashes a few users have reported. This will fix issue #50.

Also, redaction of username+passwords from log messages is fixed in this PR as I noticed that problem at the same time when a user reported logs of this crash with usernames+passwords in the errors.

Lastly, connect timeout to the database was reduced to 5 seconds to stop piling up connections. Prometheus queries the exporter every few seconds so we cannot wait 10 seconds for a connection. Plus, we're connecting to localhost.

Note: most of the lines changed in this PR are just whitespace fixes by my auto-go-linter.

Output after fix, instead of crash (database was restarted in the middle where there are errors):

```
I0309 00:54:20.719320   21709 mongodb_collector.go:64] Connected to: mongodb://****:****@localhost:27017 (node type: replset, server version: 3.2.11-3.1)
I0309 00:54:20.719336   21709 mongodb_collector.go:93] Collecting Server Status
I0309 00:54:20.721113   21709 mongodb_collector.go:103] Collecting Replset Status
I0309 00:54:20.721910   21709 mongodb_collector.go:109] Collecting Replset Oplog Status

I0309 00:54:21.771215   21709 mongodb_collector.go:64] Connected to: mongodb://****:****@localhost:27017 (node type: replset, server version: 3.2.11-3.1)
I0309 00:54:21.771233   21709 mongodb_collector.go:93] Collecting Server Status
I0309 00:54:21.773353   21709 mongodb_collector.go:103] Collecting Replset Status
I0309 00:54:21.774629   21709 mongodb_collector.go:109] Collecting Replset Oplog Status

E0309 00:54:28.003026   21709 connection.go:42] Cannot connect to server using url mongodb://****:****@localhost:27017: no reachable servers

E0309 00:54:34.569117   21709 connection.go:42] Cannot connect to server using url mongodb://****:****@localhost:27017: no reachable servers

I0309 00:54:40.648456   21709 mongodb_collector.go:64] Connected to: mongodb://****:****@localhost:27017 (node type: replset, server version: 3.2.11-3.1)
I0309 00:54:40.648482   21709 mongodb_collector.go:93] Collecting Server Status
I0309 00:54:40.651508   21709 mongodb_collector.go:103] Collecting Replset Status
I0309 00:54:40.652532   21709 mongodb_collector.go:109] Collecting Replset Oplog Status

I0309 00:54:41.710551   21709 mongodb_collector.go:64] Connected to: mongodb://****:****@localhost:27017 (node type: replset, server version: 3.2.11-3.1)
I0309 00:54:41.710571   21709 mongodb_collector.go:93] Collecting Server Status
I0309 00:54:41.712038   21709 mongodb_collector.go:103] Collecting Replset Status
I0309 00:54:41.713355   21709 mongodb_collector.go:109] Collecting Replset Oplog Status
```

Note there are no usernames/passwords printed, but I am using auth with user/pass.