### PR TITLE
Disable pre-fetching, limit conn pool and reuse db connection

### DIFF
--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -154,8 +154,8 @@ func startWebServer() {
 	}
 
 	handler := prometheusHandler()
-
-	registerCollector()
+	collector := registerCollector()
+	defer collector.Close()
 
 	if (*sslCertFileF == "") != (*sslKeyFileF == "") {
 		log.Fatal("One of the flags -web.ssl-cert-file or -web.ssl-key-file is missing to enable HTTPS/TLS")
@@ -210,7 +210,7 @@ func startWebServer() {
 	}
 }
 
-func registerCollector() {
+func registerCollector() *collector.MongodbCollector {
 	mongodbCollector := collector.NewMongodbCollector(collector.MongodbCollectorOpts{
 		URI:                   *uriF,
 		TLSConnection:         *tlsF,
@@ -220,6 +220,7 @@ func registerCollector() {
 		TLSHostnameValidation: !(*tlsDisableHostnameValidationF),
 	})
 	prometheus.MustRegister(mongodbCollector)
+	return mongodbCollector
 }
 
 func main() {

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -76,6 +76,8 @@ func MongoSession(opts MongoSessionOpts) *mgo.Session {
 		return nil
 	}
 	session.SetMode(mgo.Eventual, true)
+	session.SetPoolLimit(2)
+	session.SetPrefetch(0.00)
 	session.SetSyncTimeout(syncMongodbTimeout)
 	session.SetSocketTimeout(0)
 	return session


### PR DESCRIPTION
On many systems I've seen the mongodb_exporter use very high CPU % under PMM 1.2.x. This PR aims to reduce some of the work the mgo driver is doing and reduce the amount of connections/log-noise from reconnecting each scrape.

1. Disable cursor pre-fetching (not needed on simple exporter queries - wastes resources fetching 50 docs we won't use).
2. Limit connection pool size to 2. All other request will wait for the pool instead of creating more connections. Each additional mongodb connection adds CPU due to background pings, etc so it's best to restrict to a small number in this simple exporter.
3. Re-use database connection to MongoDB. Currently we reconnect to the DB for every single scrape - this causes MongoDB to have to create a new connection (OS thread), setup buffers etc and log a lot of noise to the logfiles. This change caches the *mgo.Session handle and re-validates it each time it is requested in the code. This results in a single mongodb connection for the runtime of the exporter and a reconnect if/when the ping to the cached handle fails. A .Close() method was added to cleanly close the cached handle at end of program.