### PR TITLE
Add MongoDB Query-comments to .Find() operations

### DIFF
--- a/collector/mongod/oplog_status.go
+++ b/collector/mongod/oplog_status.go
@@ -15,6 +15,7 @@
 package collector_mongod
 
 import (
+	"github.com/percona/mongodb_exporter/shared"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"gopkg.in/mgo.v2"
@@ -22,6 +23,8 @@ import (
 )
 
 var (
+	oplogDb          = "local"
+	oplogCollection  = "oplog.rs"
 	oplogStatusCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "replset_oplog",
@@ -69,44 +72,44 @@ func BsonMongoTimestampToUnix(timestamp bson.MongoTimestamp) float64 {
 	return float64(timestamp >> 32)
 }
 
-func GetOplogTimestamps(session *mgo.Session) (*OplogTimestamps, error) {
-	oplogTimestamps := &OplogTimestamps{}
+func getOplogTailOrHeadTimestamp(session *mgo.Session, returnHead bool) (float64, error) {
+	var result struct {
+		Timestamp bson.MongoTimestamp `bson:"ts"`
+	}
+
+	var sortCond string = "$natural"
+	if returnHead {
+		sortCond = "-$natural"
+	}
+
+	// retry once if there is an error
 	var err error
-
-	// retry once if there is an error
 	var tries int64 = 0
-	var head_result struct {
-		Timestamp bson.MongoTimestamp `bson:"ts"`
-	}
 	for tries < 2 {
-		err = session.DB("local").C("oplog.rs").Find(nil).Sort("-$natural").Limit(1).One(&head_result)
+		findQuery := session.DB(oplogDb).C(oplogCollection).Find(nil).Sort(sortCond).Limit(1)
+		err = shared.QueryWithCodeComment(findQuery).One(&result)
 		if err == nil {
 			break
 		}
 		tries += 1
 	}
-	if err != nil {
-		return oplogTimestamps, err
-	}
 
-	// retry once if there is an error
-	tries = 0
-	var tail_result struct {
-		Timestamp bson.MongoTimestamp `bson:"ts"`
-	}
-	for tries < 2 {
-		err = session.DB("local").C("oplog.rs").Find(nil).Sort("$natural").Limit(1).One(&tail_result)
-		if err == nil {
-			break
-		}
-		tries += 1
-	}
-	if err != nil {
-		return oplogTimestamps, err
-	}
+	return BsonMongoTimestampToUnix(result.Timestamp), err
+}
 
-	oplogTimestamps.Tail = BsonMongoTimestampToUnix(tail_result.Timestamp)
-	oplogTimestamps.Head = BsonMongoTimestampToUnix(head_result.Timestamp)
+func GetOplogTimestamps(session *mgo.Session) (*OplogTimestamps, error) {
+	headTs, err := getOplogTailOrHeadTimestamp(session, true)
+	if err != nil {
+		return nil, err
+	}
+	tailTs, err := getOplogTailOrHeadTimestamp(session, false)
+	if err != nil {
+		return nil, err
+	}
+	oplogTimestamps := &OplogTimestamps{
+		Head: headTs,
+		Tail: tailTs,
+	}
 	return oplogTimestamps, err
 }
 

--- a/collector/mongod/oplog_status.go
+++ b/collector/mongod/oplog_status.go
@@ -87,7 +87,7 @@ func getOplogTailOrHeadTimestamp(session *mgo.Session, returnHead bool) (float64
 	var tries int64 = 0
 	for tries < 2 {
 		findQuery := session.DB(oplogDb).C(oplogCollection).Find(nil).Sort(sortCond).Limit(1)
-		err = shared.QueryWithCodeComment(findQuery).One(&result)
+		err = shared.AddCodeCommentToQuery(findQuery).One(&result)
 		if err == nil {
 			break
 		}

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -20,13 +20,8 @@ import (
 	"io/ioutil"
 	"runtime"
 	"strconv"
-	"strings"
 
 	"gopkg.in/mgo.v2"
-)
-
-var (
-	queryCommentProgName = "mongodb_exporter"
 )
 
 func LoadCaFrom(pemFile string) (*x509.CertPool, error) {
@@ -47,8 +42,7 @@ func LoadKeyPairFrom(pemFile string, privateKeyPemFile string) (tls.Certificate,
 	return tls.LoadX509KeyPair(pemFile, targetPrivateKeyPemFile)
 }
 
-func QueryWithCodeComment(query *mgo.Query) *mgo.Query {
+func AddCodeCommentToQuery(query *mgo.Query) *mgo.Query {
 	_, fileName, lineNum, _ := runtime.Caller(1)
-	fields := []string{queryCommentProgName, fileName, strconv.Itoa(lineNum)}
-	return query.Comment(strings.Join(fields, ":"))
+	return query.Comment(fileName + ":" + strconv.Itoa(lineNum))
 }

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -18,6 +18,15 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"gopkg.in/mgo.v2"
+)
+
+var (
+	queryCommentProgName = "mongodb_exporter"
 )
 
 func LoadCaFrom(pemFile string) (*x509.CertPool, error) {
@@ -36,4 +45,10 @@ func LoadKeyPairFrom(pemFile string, privateKeyPemFile string) (tls.Certificate,
 		targetPrivateKeyPemFile = pemFile
 	}
 	return tls.LoadX509KeyPair(pemFile, targetPrivateKeyPemFile)
+}
+
+func QueryWithCodeComment(query *mgo.Query) *mgo.Query {
+	_, fileName, lineNum, _ := runtime.Caller(1)
+	fields := []string{queryCommentProgName, fileName, strconv.Itoa(lineNum)}
+	return query.Comment(strings.Join(fields, ":"))
 }


### PR DESCRIPTION
1. Added query comments to .Find() queries in oplog_status.go (only .Find() queries).
2. Cleaned up (terrible) duplicated logic/code for getting oplog timestamps that I made in oplog_status.go long ago.
3. Added a function to shared/utils.go to add code comments (File+LineNum) to MongoDB queries.

Query comment output example in Profiler:

```
test1:PRIMARY> db.system.profile.find({op:"query",ns:{$ne:"local.system.profile"}},{op:1,ns:1,query:1,command:1}).pretty()
{
	"op" : "query",
	"ns" : "local.oplog.rs",
	"query" : {
		"find" : "oplog.rs",
		"sort" : {
			"$natural" : -1
		},
		"skip" : 0,
		"limit" : 1,
		"batchSize" : 1,
		"singleBatch" : true,
		"comment" : "/home/tim/go/src/github.com/percona/mongodb_exporter/collector/mongod/oplog_status.go:90"
	}
}
{
	"op" : "query",
	"ns" : "local.oplog.rs",
	"query" : {
		"find" : "oplog.rs",
		"sort" : {
			"$natural" : 1
		},
		"skip" : 0,
		"limit" : 1,
		"batchSize" : 1,
		"singleBatch" : true,
		"comment" : "/home/tim/go/src/github.com/percona/mongodb_exporter/collector/mongod/oplog_status.go:90"
	}
}
```