### PR TITLE
 Support integration tests against non-locahost db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# editor temp files
+*.sw[nop]
+
+# build artefacts
 mongodb_exporter
 coverage.txt
 coverage_temp.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ export MONGODB_URL='mongodb://localhost:27017'
 ./mongodb_exporter
 ```
 
-`testall` make target will run integration tests.
+`testall` make target will run integration tests. Set `TEST_MONGODB_URL` to run
+against a non-localhost mongodb.
 
 
 ## Vendoring

--- a/collector/mongodb_collector_test.go
+++ b/collector/mongodb_collector_test.go
@@ -15,17 +15,26 @@
 package collector
 
 import (
+	"os"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+func testMongoURL() string {
+	val, exists := os.LookupEnv("TEST_MONGODB_URL")
+	if exists {
+		return val
+	}
+	return "mongodb://localhost:27017"
+}
 
 func TestCollector(t *testing.T) {
 	if testing.Short() {
 		t.Skip("-short is passed, skipping integration test")
 	}
 
-	collector := NewMongodbCollector(MongodbCollectorOpts{URI: "mongodb://localhost:27017"})
+	collector := NewMongodbCollector(MongodbCollectorOpts{URI: testMongoURL()})
 
 	descCh := make(chan *prometheus.Desc)
 	go func() {


### PR DESCRIPTION
Use connection string from `TEST_MONGODB_URL` envvar which defaults to `localhost:27017` still.

This makes testing against my local minikube-deployed mongodb easier. Using the `TEST_` prefix from past experience of people running tests against dbs where they actually cared about the data in by mistake when using just `MONGODB_URL`.

Also drive-by ignore my editor's temp files.