### PR TITLE
Export mongodb version as a metric

### DIFF
--- a/collector/mongod/server_status.go
+++ b/collector/mongod/server_status.go
@@ -24,6 +24,12 @@ import (
 )
 
 var (
+	versionInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "version",
+		Name:      "info",
+		Help:      "Software version information for mongodb process.",
+	}, []string{"mongodb"})
 	instanceUptimeSeconds = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: "instance",
@@ -46,6 +52,7 @@ var (
 
 // ServerStatus keeps the data returned by the serverStatus() method.
 type ServerStatus struct {
+	Version        string    `bson:"version"`
 	Uptime         float64   `bson:"uptime"`
 	UptimeEstimate float64   `bson:"uptimeEstimate"`
 	LocalTime      time.Time `bson:"localTime"`
@@ -83,6 +90,7 @@ type ServerStatus struct {
 
 // Export exports the server status to be consumed by prometheus.
 func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
+	versionInfo.WithLabelValues(status.Version).Set(1)
 	instanceUptimeSeconds.Set(status.Uptime)
 	instanceUptimeEstimateSeconds.Set(status.Uptime)
 	instanceLocalTime.Set(float64(status.LocalTime.Unix()))

--- a/collector/mongod/server_status_test.go
+++ b/collector/mongod/server_status_test.go
@@ -30,6 +30,10 @@ func TestParserServerStatus(t *testing.T) {
 	serverStatus := &ServerStatus{}
 	loadServerStatusFromBson(data, serverStatus)
 
+	if serverStatus.Version != "2.6.7" {
+		t.Errorf("Server version incorrect: %s", serverStatus.Version)
+	}
+
 	if serverStatus.Asserts == nil {
 		t.Error("Asserts group was not loaded")
 	}


### PR DESCRIPTION
Expose as a gauge with the version as a label and a value of 1.

Follows this scheme for doing software versions:
https://www.robustperception.io/exposing-the-software-version-to-prometheus/

Will conflict with https://github.com/percona/mongodb_exporter/pull/86 but I can resolve that.