### PR TITLE
Redact Mongo URI

### DIFF
--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -190,7 +190,7 @@ func (exporter *MongodbCollector) scrape(ch chan<- prometheus.Metric) {
 
 	mongoSess := exporter.getSession()
 	if mongoSess == nil {
-		err = fmt.Errorf("Can't create mongo session to %s", exporter.Opts.URI)
+		err = fmt.Errorf("Can't create mongo session to %s", shared.RedactMongoUri(exporter.Opts.URI))
 		log.Error(err)
 		exporter.mongoUp.Set(0)
 		return


### PR DESCRIPTION
Fixes URI logging in plain text including credentials when no session can be created.