### PR TITLE
PMM-2530: Add timeout flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 mongodb_exporter
 coverage.txt
 coverage_temp.txt
+/.history
+/.idea

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -41,6 +41,8 @@ type MongodbCollectorOpts struct {
 	DBPoolLimit              int
 	CollectDatabaseMetrics   bool
 	CollectCollectionMetrics bool
+	SocketTimeout            time.Duration
+	SyncTimeout              time.Duration
 }
 
 func (in *MongodbCollectorOpts) toSessionOps() *shared.MongoSessionOpts {
@@ -52,6 +54,8 @@ func (in *MongodbCollectorOpts) toSessionOps() *shared.MongoSessionOpts {
 		TLSCaFile:             in.TLSCaFile,
 		TLSHostnameValidation: in.TLSHostnameValidation,
 		PoolLimit:             in.DBPoolLimit,
+		SocketTimeout:         in.SocketTimeout,
+		SyncTimeout:           in.SyncTimeout,
 	}
 }
 

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/percona/exporter_shared"
 	"github.com/prometheus/client_golang/prometheus"
@@ -61,6 +62,9 @@ var (
 	tlsDisableHostnameValidationF = flag.Bool("mongodb.tls-disable-hostname-validation", false, "Disable hostname validation for server connection.")
 	maxConnectionsF               = flag.Int("mongodb.max-connections", 1, "Max number of pooled connections to the database.")
 	testF                         = flag.Bool("test", false, "Check MongoDB connection, print buildInfo() information and exit.")
+
+	socketTimeoutF = flag.Int64("mongodb.socket-timeout", int64(3*time.Second), "Amount of time in ms to wait for a non-responding socket to the database before it is forcefully closed")
+	syncTimeoutF   = flag.Int64("mongodb.sync-timeout", int64(1*time.Minute), "Amount of time in ms an operation with this session will wait before returning an error in case a connection to a usable server can't be established")
 
 	// FIXME currently ignored
 	// enabledGroupsFlag = flag.String("groups.enabled", "asserts,durability,background_flushing,connections,extra_info,global_lock,index_counters,network,op_counters,op_counters_repl,memory,locks,metrics", "Comma-separated list of groups to use, for more info see: docs.mongodb.org/manual/reference/command/serverStatus/")

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -63,8 +63,11 @@ var (
 	maxConnectionsF               = flag.Int("mongodb.max-connections", 1, "Max number of pooled connections to the database.")
 	testF                         = flag.Bool("test", false, "Check MongoDB connection, print buildInfo() information and exit.")
 
-	socketTimeoutF = flag.Int64("mongodb.socket-timeout", int64(3*time.Second), "Amount of time in ms to wait for a non-responding socket to the database before it is forcefully closed")
-	syncTimeoutF   = flag.Int64("mongodb.sync-timeout", int64(1*time.Minute), "Amount of time in ms an operation with this session will wait before returning an error in case a connection to a usable server can't be established")
+	socketTimeoutF = flag.Duration("mongodb.socket-timeout", 3*time.Second, "Amount of time to wait for a non-responding socket to the database before it is forcefully closed.\n"+
+		"    \tValid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.")
+	syncTimeoutF = flag.Duration("mongodb.sync-timeout", time.Minute, "Amount of time an operation with this session will wait before returning an error in case\n"+
+		"    \ta connection to a usable server can't be established.\n"+
+		"    \tValid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.")
 
 	// FIXME currently ignored
 	// enabledGroupsFlag = flag.String("groups.enabled", "asserts,durability,background_flushing,connections,extra_info,global_lock,index_counters,network,op_counters,op_counters_repl,memory,locks,metrics", "Comma-separated list of groups to use, for more info see: docs.mongodb.org/manual/reference/command/serverStatus/")

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -26,11 +26,6 @@ import (
 	"gopkg.in/mgo.v2"
 )
 
-const (
-	dialMongodbTimeout = 3 * time.Second
-	syncMongodbTimeout = 1 * time.Minute
-)
-
 func RedactMongoUri(uri string) string {
 	if strings.HasPrefix(uri, "mongodb://") && strings.Contains(uri, "@") {
 		dialInfo, err := mgo.ParseURL(uri)
@@ -53,6 +48,8 @@ type MongoSessionOpts struct {
 	TLSCaFile             string
 	TLSHostnameValidation bool
 	PoolLimit             int
+	SocketTimeout         time.Duration
+	SyncTimeout           time.Duration
 }
 
 func MongoSession(opts *MongoSessionOpts) *mgo.Session {
@@ -64,7 +61,7 @@ func MongoSession(opts *MongoSessionOpts) *mgo.Session {
 
 	// connect directly, fail faster, do not retry - for faster responses and accurate metrics, including mongoUp
 	dialInfo.Direct = true
-	dialInfo.Timeout = dialMongodbTimeout
+	dialInfo.Timeout = opts.SocketTimeout
 	dialInfo.FailFast = true
 
 	err = opts.configureDialInfoIfRequired(dialInfo)
@@ -81,8 +78,8 @@ func MongoSession(opts *MongoSessionOpts) *mgo.Session {
 	session.SetMode(mgo.Eventual, true)
 	session.SetPoolLimit(opts.PoolLimit)
 	session.SetPrefetch(0.00)
-	session.SetSyncTimeout(syncMongodbTimeout)
-	session.SetSocketTimeout(dialMongodbTimeout)
+	session.SetSyncTimeout(opts.SyncTimeout)
+	session.SetSocketTimeout(opts.SocketTimeout)
 	return session
 }
 


### PR DESCRIPTION
Adds the following flags:

* -mongodb.socket-timeout
* -mongodb.sync-timeout

I left the defaults as they were, but I think it might be a good idea to change them as well. The MongoDB driver has a default for the sync timeout of 7 seconds ([session.go#L1706](https://github.com/percona/mongodb_exporter/blob/develop/vendor/gopkg.in/mgo.v2/session.go#L1706)) and a default value for the socket timeout of one minute ([session.go#L1716](https://github.com/percona/mongodb_exporter/blob/develop/vendor/gopkg.in/mgo.v2/session.go#L1716)) whereas the exporter uses a much longer default for the sync timeout of one minute and an extremely short default of 3 seconds for the socket timeout.

We've found that the default socket timeout is way too short when you have a recovering replica. It may take quite a bit to connect. You want to make sure to get your metrics, so I'd rather set the timeout higher.