### PR TITLE
Build binaries

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,8 @@
 repository:
   path: github.com/percona/mongodb_exporter
 build:
+  binaries:
+    - name: mongodb_exporter
   flags: -v -a -tags netgo
   ldflags: |
     -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}
@@ -13,3 +15,13 @@ tarball:
     - README.md
     - CHANGELOG.md
     - LICENSE
+crossbuild:
+  platforms:
+    - linux/amd64
+    - linux/386
+    - darwin/amd64
+    - darwin/386
+    - netbsd/amd64
+    - netbsd/386
+    - linux/arm
+    - linux/arm64


### PR DESCRIPTION
It seems that none of the releases since v0.3.1 include binaries. I'm not sure if this is intentional, but this exporter is much easier to use if I can simply download a precompiled binary directly from GitHub rather than compiling and packaging the exporter myself.

NOTE: I have no idea if the changes made in this pull request will actually fix this issue. I inspect the code changes between v0.3.1 and v0.3.2 and can't see anything obvious which would have resulted in binaries no longer being published. Although, I'm not sure what the release process for this exporter even looks like so it's possible that the maintainers are publishing new versions locally rather than using [Travis](https://docs.travis-ci.com/user/deployment/releases/) and that the omission of binaries was a simple oversight.