### PR TITLE
Fix typo. Make the environment variable MONGODB_URL not MONGODB_URI

### DIFF
--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -84,7 +84,7 @@ func main() {
 	}
 	flag.Parse()
 
-	uri := os.Getenv("MONGODB_URI")
+	uri := os.Getenv("MONGODB_URL")
 	if uri != "" {
 		uriF = &uri
 	}


### PR DESCRIPTION
Despite the flag being called mongodb.uri, the documentation and the default
value of mongdb.uri refer to the env var MONGODB_URL

When overriding this prior to creating a test connection , the value of os.GetEnv("MONGODB_URI") is used to override. 

In the scenario where you've got mongodb_exporter being launched with a flag for the mongdb.uri AND you're overriding that with MONGODB_URL in the environment. Results are confusing.