### PR TITLE
PMM-3106: Be consistent and use MONGODB_URI everywhere.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ make all testall
 ```
 
 `testall` make target will run integration tests against MongoDB instance specified in
-`TEST_MONGODB_URL` environment variable (defaults to `mongodb://localhost:27017`).
+`TEST_MONGODB_URI` environment variable (defaults to `mongodb://localhost:27017`).
 
 
 ## Vendoring

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ make
 
 ### Running
 
-To define your own MongoDB URL, use environment variable `MONGODB_URL`. If set this variable takes precedence over `-mongodb.uri` flag.
+To define your own MongoDB URL, use environment variable `MONGODB_URI`. If set this variable takes precedence over `-mongodb.uri` flag.
 
 To enable HTTP basic authentication, set environment variable `HTTP_AUTH` to user:password pair. Alternatively, you can
 use YAML file with `server_user` and `server_password` fields.
 
 ```bash
-export MONGODB_URL='mongodb://localhost:27017'
+export MONGODB_URI='mongodb://localhost:27017'
 export HTTP_AUTH='user:password'
 ./mongodb_exporter <flags>
 ```
@@ -59,10 +59,10 @@ db.getSiblingDB("admin").createUser({
 })
 ```
 
-2. Set environment variable `MONGODB_URL` before starting the exporter:
+2. Set environment variable `MONGODB_URI` before starting the exporter:
 
 ```bash
-export MONGODB_URL=mongodb://mongodb_exporter:s3cr3tpassw0rd@localhost:27017
+export MONGODB_URI=mongodb://mongodb_exporter:s3cr3tpassw0rd@localhost:27017
 ```
 
 If you use [x.509 Certificates to Authenticate Clients](https://docs.mongodb.com/manual/tutorial/configure-x509-client-authentication/), pass in username and `authMechanism` via [connection options](https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options) to the MongoDB uri. Eg:

--- a/collector/mongodb_collector_test.go
+++ b/collector/mongodb_collector_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func testMongoDBURL() string {
-	if u := os.Getenv("TEST_MONGODB_URL"); u != "" {
+	if u := os.Getenv("TEST_MONGODB_URI"); u != "" {
 		return u
 	}
 	return "mongodb://localhost:27017"

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -34,8 +34,8 @@ const (
 	program = "mongodb_exporter"
 )
 
-func defaultMongoDBURL() string {
-	if u := os.Getenv("MONGODB_URL"); u != "" {
+func defaultMongoDBURI() string {
+	if u := os.Getenv("MONGODB_URI"); u != "" {
 		return u
 	}
 	return "mongodb://localhost:27017"
@@ -51,7 +51,7 @@ var (
 	collectTopF        = flag.Bool("collect.topmetrics", false, "Enable collection of table top metrics")
 	collectIndexUsageF = flag.Bool("collect.indexusage", false, "Enable collection of per index usage stats")
 
-	uriF     = flag.String("mongodb.uri", defaultMongoDBURL(), "MongoDB URI, format: [mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]")
+	uriF     = flag.String("mongodb.uri", defaultMongoDBURI(), "MongoDB URI, format: [mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]")
 	tlsF     = flag.Bool("mongodb.tls", false, "Enable tls connection with mongo server")
 	tlsCertF = flag.String("mongodb.tls-cert", "", "Path to PEM file that contains the certificate (and optionally also the decrypted private key in PEM format).\n"+
 		"    \tThis should include the whole certificate chain.\n"+


### PR DESCRIPTION
Be consistent in  usage of env var MONGODB_URI.   Currently, documentation say "MONGODB_URL", but code is looking for MONGODB_URI.
