### PR TITLE
A fix of labels for wiredtiger_concurrent_transactions_out_tickets

### DIFF
--- a/collector/mongod/wiredtiger.go
+++ b/collector/mongod/wiredtiger.go
@@ -335,8 +335,8 @@ type WTConcurrentTransactionsTypeStats struct {
 }
 
 type WTConcurrentTransactionsStats struct {
-	Write *WTConcurrentTransactionsTypeStats `bson:"read"`
-	Read  *WTConcurrentTransactionsTypeStats `bson:"write"`
+	Read *WTConcurrentTransactionsTypeStats `bson:"read"`
+	Write  *WTConcurrentTransactionsTypeStats `bson:"write"`
 }
 
 func (stats *WTConcurrentTransactionsStats) Export(ch chan<- prometheus.Metric) {


### PR DESCRIPTION
A small typo seems to have happened. Read tickets out were labelled as write, and vice versa. This reverses that.