### PR TITLE
deploy builds to github releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ coverage.txt
 coverage_temp.txt
 /.history
 /.idea
+
+# promu
+.build
+.tarballs

--- a/.promu.yml
+++ b/.promu.yml
@@ -21,7 +21,24 @@ crossbuild:
     - linux/386
     - darwin/amd64
     - darwin/386
+    - windows/amd64
+    - windows/386
+    - freebsd/amd64
+    - freebsd/386
+    - openbsd/amd64
+    - openbsd/386
     - netbsd/amd64
     - netbsd/386
+    - dragonfly/amd64
     - linux/arm
     - linux/arm64
+    - freebsd/arm
+    # Temporarily deactivated as golang.org/x/sys does not have syscalls
+    # implemented for that os/platform combination.
+    #- openbsd/arm
+    #- linux/mips64
+    #- linux/mips64le
+    - netbsd/arm
+    - linux/ppc64
+    - linux/ppc64le
+    - linux/s390x

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,23 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash) -X fix
 
+before_deploy:
+  - go get -v github.com/prometheus/promu
+  - promu crossbuild
+  - promu crossbuild tarballs
+  - promu checksum .tarballs
+
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  file_glob: true
+  file: .tarballs/*
+  on:
+    tags: true
+    branch: master
+    condition: $MONGODB_IMAGE = mongo:3.6 # onyl do it once
+
 notifications:
   slack:
     on_success: change


### PR DESCRIPTION
This PR adds a deployment step to Travis to upload the binaries to a release on Github. 

As I wasn't able to make the build work on my fork without some changes I tested it in the master branch but committed only the required changes on this PR:
https://github.com/thde/mongodb_exporter/releases/tag/v0.6.2.3
https://travis-ci.com/thde/mongodb_exporter/jobs/162384188

The `.promu.yml` crossbuils vars are based on the ones prometheus uses: https://github.com/prometheus/prometheus/blob/master/.promu.yml

Someone would need to set the `GITHUB_OAUTH_TOKEN` var in the Travis settings to allow the upload.