### PR TITLE
PMM-3524: Add information about missing metrics in test.

### DIFF
--- a/collector/mongodb_collector_test.go
+++ b/collector/mongodb_collector_test.go
@@ -15,6 +15,7 @@
 package collector
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -55,7 +56,7 @@ func TestCollector(t *testing.T) {
 		close(metricCh)
 	}()
 
-	var descriptors = make(map[string]struct{})
+	descriptors := make(map[string]struct{})
 	var descriptorsCount int
 	for d := range descCh {
 		descriptors[d.String()] = struct{}{}
@@ -78,8 +79,13 @@ func TestCollector(t *testing.T) {
 		metricsCount++
 	}
 
-	assert.Emptyf(t, descriptors, "Number of descriptors collected and described should be the same. "+
-		"Got '%d' Descriptors from collector.Describe()"+
-		" and '%d' from collector.Collect().", descriptorsCount, metricsCount)
+	var missingDescMsg string
+	for k := range descriptors {
+		missingDescMsg += fmt.Sprintf("- %s\n", k)
+	}
+
+	assert.True(t, len(descriptors) == 0, "Number of descriptors collected and described should be the same. "+
+		"Got '%d' Descriptors from collector.Describe() and '%d' from collector.Collect().\n"+
+		"Missing descriptors: \n%s", descriptorsCount, metricsCount, missingDescMsg)
 	assert.True(t, versionInfoFound, "version info metric not found")
 }

--- a/collector/mongodb_collector_test.go
+++ b/collector/mongodb_collector_test.go
@@ -15,6 +15,7 @@
 package collector
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -56,13 +57,18 @@ func TestCollector(t *testing.T) {
 	}()
 
 	var descs int
-	for range descCh {
+	var descsAsString string
+	for d := range descCh {
+		descsAsString += fmt.Sprintf("%s\n", d.String())
 		descs++
 	}
 
 	var metrics int
+	var metricsAsString string
 	var versionInfoFound bool
 	for m := range metricCh {
+		metricsAsString += fmt.Sprintf("%s\n", m.Desc().String())
+
 		m := helpers.ReadMetric(m)
 		switch m.Name {
 		case "mongodb_version_info":
@@ -71,6 +77,8 @@ func TestCollector(t *testing.T) {
 		metrics++
 	}
 
-	assert.Equalf(t, descs, metrics, "got %d descs and %d metrics", descs, metrics)
+	assert.Equalf(t, descsAsString, metricsAsString, "Number of descriptors collected and described should be the same. "+
+		"Got '%d' Descriptors from collector.Describe()"+
+		" and '%d' from collector.Collect().", descs, metrics)
 	assert.True(t, versionInfoFound, "version info metric not found")
 }


### PR DESCRIPTION
From this moment we can see which metrics wasn't described and/or collected when test fails.