### PR TITLE
Add Authentification Database option when connect to mongo

### DIFF
--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -45,6 +45,7 @@ type MongodbCollectorOpts struct {
 	CollectIndexUsageStats   bool
 	SocketTimeout            time.Duration
 	SyncTimeout              time.Duration
+	AuthentificationDB       string
 }
 
 func (in *MongodbCollectorOpts) toSessionOps() *shared.MongoSessionOpts {
@@ -58,6 +59,7 @@ func (in *MongodbCollectorOpts) toSessionOps() *shared.MongoSessionOpts {
 		PoolLimit:             in.DBPoolLimit,
 		SocketTimeout:         in.SocketTimeout,
 		SyncTimeout:           in.SyncTimeout,
+		AuthentificationDB:    in.AuthentificationDB,
 	}
 }
 

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -52,6 +52,7 @@ var (
 		Envar("MONGODB_URI").
 		String()
 
+	authDB   = kingpin.Flag("mongodb.authentification-database", "Specifies the database in which the user is created").Default("").String()
 	tlsF     = kingpin.Flag("mongodb.tls", "Enable tls connection with mongo server").Bool()
 	tlsCertF = kingpin.Flag("mongodb.tls-cert", "Path to PEM file that contains the certificate (and optionally also the decrypted private key in PEM format).\n"+
 		"    \tThis should include the whole certificate chain.\n"+
@@ -88,6 +89,7 @@ func main() {
 				TLSPrivateKeyFile:     *tlsPrivateKeyF,
 				TLSCaFile:             *tlsCAF,
 				TLSHostnameValidation: !(*tlsDisableHostnameValidationF),
+				AuthentificationDB:    *authDB,
 			},
 		)
 		if err != nil {
@@ -118,6 +120,7 @@ func main() {
 		CollectIndexUsageStats:   *collectIndexUsageF,
 		SocketTimeout:            *socketTimeoutF,
 		SyncTimeout:              *syncTimeoutF,
+		AuthentificationDB:       *authDB,
 	})
 	prometheus.MustRegister(programCollector, mongodbCollector)
 

--- a/shared/connection.go
+++ b/shared/connection.go
@@ -54,6 +54,7 @@ type MongoSessionOpts struct {
 	PoolLimit             int
 	SocketTimeout         time.Duration
 	SyncTimeout           time.Duration
+	AuthentificationDB    string
 }
 
 // MongoSession connects to MongoDB and returns ready to use MongoDB session.
@@ -72,6 +73,7 @@ func MongoSession(opts *MongoSessionOpts) *mgo.Session {
 	dialInfo.Direct = true
 	dialInfo.Timeout = opts.SocketTimeout
 	dialInfo.FailFast = true
+	dialInfo.Source = opts.AuthentificationDB
 
 	err = opts.configureDialInfoIfRequired(dialInfo)
 	if err != nil {

--- a/testdata/mongodb_exporter.testFlagHelp.golden
+++ b/testdata/mongodb_exporter.testFlagHelp.golden
@@ -16,6 +16,9 @@ Flags:
       --collect.indexusage       Enable collection of per index usage stats
       --mongodb.uri=[mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]  
                                  MongoDB URI, format
+      --mongodb.authentification-database=""  
+                                 Specifies the database in which the user is
+                                 created
       --mongodb.tls              Enable tls connection with mongo server
       --mongodb.tls-cert=""      Path to PEM file that contains the certificate
                                  (and optionally also the decrypted private key


### PR DESCRIPTION
I would like to be able to reproduce behaviour similar to mongo client flag : `--authenticationDatabase`

Associated mongo client documentation : https://docs.mongodb.com/manual/reference/program/mongo/#cmdoption-mongo-authenticationdatabase

If not setting, default will be an empty string  and behaviour will be similar to the actual. Mongo will use the same database that defined in the connection string.
