### PR TITLE
return missing metrics from mongos

### DIFF
--- a/collector/common/op_counters.go
+++ b/collector/common/op_counters.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mongod
+package collector_common
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/collector/common/server_status.go
+++ b/collector/common/server_status.go
@@ -60,6 +60,9 @@ type ServerStatus struct {
 	ExtraInfo   *ExtraInfo       `bson:"extra_info"`
 	Mem         *MemStats        `bson:"mem"`
 	Network     *NetworkStats    `bson:"network"`
+
+	Opcounters     *OpcountersStats     `bson:"opcounters"`
+	OpcountersRepl *OpcountersReplStats `bson:"opcountersRepl"`
 }
 
 // Export exports the server status to be consumed by prometheus.
@@ -90,6 +93,12 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 	}
 	if status.Network != nil {
 		status.Network.Export(ch)
+	}
+	if status.Opcounters != nil {
+		status.Opcounters.Export(ch)
+	}
+	if status.OpcountersRepl != nil {
+		status.OpcountersRepl.Export(ch)
 	}
 }
 

--- a/collector/mongod/server_status.go
+++ b/collector/mongod/server_status.go
@@ -20,7 +20,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/percona/mongodb_exporter/collector/common"
+	collector_common "github.com/percona/mongodb_exporter/collector/common"
 )
 
 // ServerStatus keeps the data returned by the serverStatus() method.
@@ -37,10 +37,8 @@ type ServerStatus struct {
 
 	Locks LockStatsMap `bson:"locks,omitempty"`
 
-	OpLatencies    *OpLatenciesStat     `bson:"opLatencies"`
-	Opcounters     *OpcountersStats     `bson:"opcounters"`
-	OpcountersRepl *OpcountersReplStats `bson:"opcountersRepl"`
-	Metrics        *MetricsStats        `bson:"metrics"`
+	OpLatencies *OpLatenciesStat `bson:"opLatencies"`
+	Metrics     *MetricsStats    `bson:"metrics"`
 
 	StorageEngine *StorageEngineStats `bson:"storageEngine"`
 	InMemory      *WiredTigerStats    `bson:"inMemory"`
@@ -66,12 +64,6 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 	if status.OpLatencies != nil {
 		status.OpLatencies.Export(ch)
 	}
-	if status.Opcounters != nil {
-		status.Opcounters.Export(ch)
-	}
-	if status.OpcountersRepl != nil {
-		status.OpcountersRepl.Export(ch)
-	}
 	if status.Locks != nil {
 		status.Locks.Export(ch)
 	}
@@ -87,7 +79,6 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 	if status.WiredTiger != nil {
 		status.WiredTiger.Export(ch)
 	}
-
 	// If db.serverStatus().storageEngine does not exist (3.0+ only) and status.BackgroundFlushing does (MMAPv1 only), default to mmapv1
 	// https://docs.mongodb.com/v3.0/reference/command/serverStatus/#storageengine
 	if status.StorageEngine == nil && status.BackgroundFlushing != nil {


### PR DESCRIPTION
Hi! When metrics were split on common and mongo(d\s), metric "mongodb_op_counters_total" from ServerStatus was lost on mongos.