### PR TITLE
PMM-4236 Move test coverage to different stage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: go
 stages:
   - build
   - test
-  - test-coverage
   - deploy
 
 go:
@@ -41,11 +40,6 @@ jobs:
       script:
         - make check-vendor-synced style build
 
-    - stage: test-coverage
-      script:
-        - make test-coverage
-      after_success: bash <(curl -s https://codecov.io/bash) -X fix
-
     - stage: deploy
       script: skip
       deploy:
@@ -53,6 +47,11 @@ jobs:
         script: make community-release
         on:
           tags: true
+
+after_success:
+  - curl https://codecov.io/bash > codecov
+  - chmod +x codecov
+  - timeout 10 ./codecov -X fix
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: go
 stages:
   - build
   - test
+  - test-coverage
   - deploy
 
 go:
@@ -40,6 +41,11 @@ jobs:
       script:
         - make check-vendor-synced style build
 
+    - stage: test-coverage
+      script:
+        - make test-coverage
+      after_success: bash <(curl -s https://codecov.io/bash) -X fix
+
     - stage: deploy
       script: skip
       deploy:
@@ -47,8 +53,6 @@ jobs:
         script: make community-release
         on:
           tags: true
-
-after_success: bash <(curl -s https://codecov.io/bash) -X fix
 
 notifications:
   slack:

--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,15 @@ style:
 
 test: init mongo-db-in-docker
 	@echo ">> running tests"
-	go test -coverprofile=coverage.txt -short -v $(RACE) $(pkgs)
+	go test -short -v $(RACE) $(pkgs)
 
 test-all: init mongo-db-in-docker
 	@echo ">> running all tests"
-	go test -coverprofile=coverage.txt -v $(RACE) $(pkgs)
+	go test -v $(RACE) $(pkgs)
+
+test-coverage: init mongo-db-in-docker
+	@echo ">> running test coverage"
+	go test -coverprofile=coverage.txt -v $(pkgs)
 
 format:
 	@echo ">> formatting code"

--- a/Makefile
+++ b/Makefile
@@ -39,21 +39,21 @@ export PMM_RELEASE_TIMESTAMP  = $(shell date '+%s')
 export PMM_RELEASE_FULLCOMMIT = $(APP_REVISION)
 export PMM_RELEASE_BRANCH     = $(TRAVIS_BRANCH)
 
-all: clean format build test
+all: clean format style build test-all
 
 style:
 	@echo ">> checking code style"
 	@! gofmt -s -d $(shell find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
 
-test: init mongo-db-in-docker
+test: mongo-db-in-docker
 	@echo ">> running tests"
 	go test -short -v $(RACE) $(pkgs)
 
-test-all: init mongo-db-in-docker
+test-all: mongo-db-in-docker
 	@echo ">> running all tests"
 	go test -v $(RACE) $(pkgs)
 
-test-coverage: init mongo-db-in-docker
+test-coverage: mongo-db-in-docker
 	@echo ">> running test coverage"
 	go test -coverprofile=coverage.txt -v $(pkgs)
 
@@ -101,10 +101,8 @@ $(GOPATH)/bin/dep:
 $(GOPATH)/bin/goreleaser:
 	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=$(GOPATH)/bin sh
 
-init: $(GOPATH)/bin/dep $(GOPATH)/bin/goreleaser
-
 # Ensure that vendor/ is in sync with code and Gopkg.*
-check-vendor-synced: init
+check-vendor-synced: $(GOPATH)/bin/dep
 	rm -fr vendor/
 	dep ensure -v
 	git diff --exit-code
@@ -126,4 +124,4 @@ mongo-db-in-docker:
 	docker-compose --version
 	docker-compose exec mongo mongo --version
 
-.PHONY: init all style format build release test vet release docker clean check-vendor-synced mongo-db-in-docker
+.PHONY: all style format build release test vet release docker clean check-vendor-synced mongo-db-in-docker


### PR DESCRIPTION
Here I have refactored `Makefile` and `.travis-ci.yml` a little bit, to improve CI speed.
You can compare builds [№740](https://travis-ci.com/percona/mongodb_exporter/builds/116636634) with [№733](https://travis-ci.com/percona/mongodb_exporter/builds/116619646). Look not only in total timing but also in different stages.

In the luckiest case, the total run time will be probably the same. About `7m30s`. 
But in the worst case (for example, if each Codeconv report will be working for `5m`) the new pipeline will be faster a lot because it runs only once, not after each testing job. Also, it would never run if some of the tests fail because it's in a different stage.