### PR TITLE
PMM-4902 Making the metrics descriptions reflect the upstream mongodb diagnostic source. (Except for RocksDB)

### DIFF
--- a/collector/common/asserts.go
+++ b/collector/common/asserts.go
@@ -21,7 +21,7 @@ import (
 var (
 	assertsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "asserts_total"),
-		"The asserts document reports the number of asserts on the database. While assert errors are typically uncommon, if there are non-zero values for the asserts, you should check the log file for the mongod process for more information. In many cases these errors are trivial, but are worth investigating.",
+		"= serverStatus asserts",
 		[]string{"type"},
 		nil,
 	)

--- a/collector/common/conn_pool_stats.go
+++ b/collector/common/conn_pool_stats.go
@@ -13,35 +13,35 @@ import (
 var (
 	syncClientConnectionsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connpoolstats", "connection_sync"),
-		"Corresponds to the total number of client connections to mongo.",
+		"= connPoolStats numClientConnections",
 		nil,
 		nil,
 	)
 
 	numAScopedConnectionsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connpoolstats", "connections_scoped_sync"),
-		"Corresponds to the number of active and stored outgoing scoped synchronous connections from the current instance to other members of the sharded cluster or replica set.",
+		"= connPoolStats numAScopedConnections",
 		nil,
 		nil,
 	)
 
 	totalInUseDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connpoolstats", "connections_in_use"),
-		"Corresponds to the total number of client connections to mongo currently in use.",
+		"= connPoolStats totalInUse",
 		nil,
 		nil,
 	)
 
 	totalAvailableDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connpoolstats", "connections_available"),
-		"Corresponds to the total number of client connections to mongo that are currently available.",
+		"= connPoolStats totalAvailable",
 		nil,
 		nil,
 	)
 
 	totalCreatedDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connpoolstats", "connections_created_total"),
-		"Corresponds to the total number of client connections to mongo created since instance start",
+		"= connPoolStats totalCreated",
 		nil,
 		nil,
 	)

--- a/collector/common/connections.go
+++ b/collector/common/connections.go
@@ -28,7 +28,7 @@ var (
 var (
 	connectionsMetricsCreatedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connections_metrics", "created_total"),
-		"source = serverStatsus connections.totalCreated",
+		"source = serverStatus connections.totalCreated",
 		nil,
 		nil,
 	)

--- a/collector/common/connections.go
+++ b/collector/common/connections.go
@@ -22,13 +22,13 @@ var (
 	connections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "connections",
-		Help:      "source = serverStatus connections.[current|available]",
+		Help:      "= serverStatus connections.[current|available]",
 	}, []string{"state"})
 )
 var (
 	connectionsMetricsCreatedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connections_metrics", "created_total"),
-		"source = serverStatus connections.totalCreated",
+		"= serverStatus connections.totalCreated",
 		nil,
 		nil,
 	)

--- a/collector/common/connections.go
+++ b/collector/common/connections.go
@@ -22,13 +22,13 @@ var (
 	connections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "connections",
-		Help:      "The connections sub document data regarding the current status of incoming connections and availability of the database server. Use these values to assess the current load and capacity requirements of the server",
+		Help:      "source = serverStatus connections.[current|available]",
 	}, []string{"state"})
 )
 var (
 	connectionsMetricsCreatedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connections_metrics", "created_total"),
-		"totalCreated provides a count of all incoming connections created to the server. This number includes connections that have since closed",
+		"source = serverStatsus connections.totalCreated",
 		nil,
 		nil,
 	)

--- a/collector/common/cursors.go
+++ b/collector/common/cursors.go
@@ -19,10 +19,11 @@ import (
 )
 
 var (
+	//N.b. this is not "metrics.cursor.*" this is "cursors.*" which only exists in <= 3.0
 	cursorsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "cursors",
-		Help:      "The cursors data structure contains data regarding cursor state and use",
+		Help:      "source = serverStatus cursors",
 	}, []string{"state"})
 )
 

--- a/collector/common/cursors.go
+++ b/collector/common/cursors.go
@@ -23,7 +23,7 @@ var (
 	cursorsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "cursors",
-		Help:      "source = serverStatus cursors",
+		Help:      "= serverStatus cursors",
 	}, []string{"state"})
 )
 

--- a/collector/common/extra_info.go
+++ b/collector/common/extra_info.go
@@ -23,13 +23,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "extra_info",
 		Name:      "page_faults_total",
-		Help:      "source = serverStatus extra_info.page_faults",
+		Help:      "= serverStatus extra_info.page_faults",
 	})
 	extraInfoheapUsageBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "extra_info",
 		Name:      "heap_usage_bytes",
-		Help:      "source = serverStatus extra_info.heap_usage_bytes",
+		Help:      "= serverStatus extra_info.heap_usage_bytes",
 	})
 )
 

--- a/collector/common/extra_info.go
+++ b/collector/common/extra_info.go
@@ -23,13 +23,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "extra_info",
 		Name:      "page_faults_total",
-		Help:      "The page_faults Reports the total number of page faults that require disk operations. Page faults refer to operations that require the database server to access data which isn’t available in active memory. The page_faults counter may increase dramatically during moments of poor performance and may correlate with limited memory environments and larger data sets. Limited and sporadic page faults do not necessarily indicate an issue",
+		Help:      "source = serverStatus extra_info.page_faults",
 	})
 	extraInfoheapUsageBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "extra_info",
 		Name:      "heap_usage_bytes",
-		Help:      "The heap_usage_bytes field is only available on Unix/Linux systems, and reports the total size in bytes of heap space used by the database process",
+		Help:      "source = serverStatus extra_info.heap_usage_bytes",
 	})
 )
 

--- a/collector/common/memory.go
+++ b/collector/common/memory.go
@@ -22,7 +22,7 @@ var (
 	memory = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "memory",
-		Help:      "source = serverStatus mem",
+		Help:      "= serverStatus mem",
 	}, []string{"type"})
 )
 

--- a/collector/common/memory.go
+++ b/collector/common/memory.go
@@ -22,7 +22,7 @@ var (
 	memory = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "memory",
-		Help:      "The mem data structure holds information regarding the target system architecture of mongod and current memory use",
+		Help:      "source = serverStatus mem",
 	}, []string{"type"})
 )
 

--- a/collector/common/network.go
+++ b/collector/common/network.go
@@ -21,7 +21,7 @@ import (
 var (
 	networkBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "network_bytes_total"),
-		"The network data structure contains data regarding MongoDB’s network use",
+		"= serverStatus network.[bytesIn|bytesOut]",
 		[]string{"state"},
 		nil,
 	)
@@ -29,7 +29,7 @@ var (
 var (
 	networkMetricsNumRequestsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "network_metrics", "num_requests_total"),
-		"The numRequests field is a counter of the total number of distinct requests that the server has received. Use this value to provide context for the bytesIn and bytesOut values to ensure that MongoDB’s network utilization is consistent with expectations and application use",
+		"= serverStatus network.numRequests",
 		nil,
 		nil,
 	)

--- a/collector/common/op_counters.go
+++ b/collector/common/op_counters.go
@@ -21,7 +21,7 @@ import (
 var (
 	opCountersTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "op_counters_total"),
-		"The opcounters data structure provides an overview of database operations by type and makes it possible to analyze the load on the database in more granular manner. These numbers will grow over time and in response to database use. Analyze these values over time to track database utilization",
+		"= serverStatus opCounters",
 		[]string{"type"},
 		nil,
 	)
@@ -30,7 +30,7 @@ var (
 var (
 	opCountersReplTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "op_counters_repl_total"),
-		"The opcountersRepl data structure, similar to the opcounters data structure, provides an overview of database replication operations by type and makes it possible to analyze the load on the replica in more granular manner. These values only appear when the current host has replication enabled",
+		"= serverStatus opCountersRepl",
 		[]string{"type"},
 		nil,
 	)

--- a/collector/common/server_status.go
+++ b/collector/common/server_status.go
@@ -25,23 +25,23 @@ var (
 		Namespace: Namespace,
 		Subsystem: "version",
 		Name:      "info",
-		Help:      "Software version information for mongodb process.",
+		Help:      "source = serverStatus version",
 	}, []string{"mongodb"})
 	instanceUptimeSecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "instance", "uptime_seconds"),
-		"The value of the uptime field corresponds to the number of seconds that the mongos or mongod process has been active.",
+		"source = serverStatus uptime",
 		nil,
 		nil,
 	)
 	instanceUptimeEstimateSecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "instance", "uptime_estimate_seconds"),
-		"uptimeEstimate provides the uptime as calculated from MongoDB's internal course-grained time keeping system.",
+		"source = serverStatus uptimeEstimate",
 		nil,
 		nil,
 	)
 	instanceLocalTimeDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "instance", "local_time"),
-		"The localTime value is the current time, according to the server, in UTC specified in an ISODate format.",
+		"source = serverStatus localTime",
 		nil,
 		nil,
 	)

--- a/collector/common/server_status.go
+++ b/collector/common/server_status.go
@@ -25,23 +25,23 @@ var (
 		Namespace: Namespace,
 		Subsystem: "version",
 		Name:      "info",
-		Help:      "source = serverStatus version",
+		Help:      "= serverStatus version",
 	}, []string{"mongodb"})
 	instanceUptimeSecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "instance", "uptime_seconds"),
-		"source = serverStatus uptime",
+		"= serverStatus uptime",
 		nil,
 		nil,
 	)
 	instanceUptimeEstimateSecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "instance", "uptime_estimate_seconds"),
-		"source = serverStatus uptimeEstimate",
+		"= serverStatus uptimeEstimate",
 		nil,
 		nil,
 	)
 	instanceLocalTimeDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "instance", "local_time"),
-		"source = serverStatus localTime",
+		"= serverStatus localTime",
 		nil,
 		nil,
 	)

--- a/collector/common/tcmalloc.go
+++ b/collector/common/tcmalloc.go
@@ -7,42 +7,43 @@ import (
 var (
 	tcmallocGeneralDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "tcmalloc", "generic_heap"),
-		"High-level summary metricsInternal metrics from tcmalloc",
+		"= serverStatus tcmalloc.generic.[current_allocated_bytes|heap_size]",
 		[]string{"type"},
 		nil,
 	)
 
 	tcmallocPageheapBytesDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "tcmalloc", "pageheap_bytes"),
-		"Sizes for tcpmalloc pageheaps",
+		"= serverStatus tcmalloc.tcmalloc.pageheap_[free|unmapped|committed|total_commit|total_decommit|total_reserve]_bytes",
 		[]string{"type"},
 		nil,
 	)
 
+
 	tcmallocPageheapCountsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "tcmalloc", "pageheap_count"),
-		"Sizes for tcpmalloc pageheaps",
+		"= serverStatus tcmalloc.tcmalloc.pageheap_[scavenge|commit|decommit|reserve]_count",
 		[]string{"type"},
 		nil,
 	)
 
 	tcmallocCacheBytesDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "tcmalloc", "cache_bytes"),
-		"Sizes for tcpmalloc caches in bytes",
+		"= serverStatus tcmalloc.tcmalloc.[max_total_thread_cache_bytes|current_total_thread_cache_bytes|central_cache_free_bytes|transfer_cache_free_bytes|thread_cache_free_bytes]",
 		[]string{"cache", "type"},
 		nil,
 	)
 
 	tcmallocAggressiveDecommitDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "tcmalloc", "aggressive_memory_decommit"),
-		"Whether aggressive_memory_decommit is on",
+		"= serverStatus tcmalloc.tcmalloc.aggressive_memory_decommit",
 		nil,
 		nil,
 	)
 
 	tcmallocFreeBytesDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "tcmalloc", "free_bytes"),
-		"Total free bytes of tcmalloc",
+		"= serverStatus tcmalloc.tcmalloc.total_free_bytes",
 		nil,
 		nil,
 	)

--- a/collector/mongod/background_flushing.go
+++ b/collector/mongod/background_flushing.go
@@ -23,13 +23,13 @@ import (
 var (
 	backgroundFlushingflushesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "background_flushing", "flushes_total"),
-		"flushes is a counter that collects the number of times the database has flushed all writes to disk. This value will grow as database runs for longer periods of time",
+		"source = serverStatus backgroundFlushing.flushes",
 		nil,
 		nil,
 	)
 	backgroundFlushingtotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "background_flushing", "total_milliseconds"),
-		"The total_ms value provides the total number of milliseconds (ms) that the mongod processes have spent writing (i.e. flushing) data to disk. Because this is an absolute value, consider the value offlushes and average_ms to provide better context for this datum",
+		"source = serverStatus backgroundFlushing.total_ms",
 		nil,
 		nil,
 	)
@@ -37,19 +37,19 @@ var (
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "average_milliseconds",
-		Help:      `The average_ms value describes the relationship between the number of flushes and the total amount of time that the database has spent writing data to disk. The larger flushes is, the more likely this value is likely to represent a "normal," time; however, abnormal data can skew this value`,
+		Help:      "source = serverStatus backgroundFlushing.average_ms",
 	})
 	backgroundFlushinglastMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "last_milliseconds",
-		Help:      "The value of the last_ms field is the amount of time, in milliseconds, that the last flush operation took to complete. Use this value to verify that the current performance of the server and is in line with the historical data provided by average_ms and total_ms",
+		Help:      "source = serverStatus backgroundFlushing.last_ms",
 	})
 	backgroundFlushinglastFinishedTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "last_finished_time",
-		Help:      "The last_finished field provides a timestamp of the last completed flush operation in the ISODateformat. If this value is more than a few minutes old relative to your server’s current time and accounting for differences in time zone, restarting the database may result in some data loss",
+		Help:      "source = serverStatus backgroundFlushing.last_finished",
 	})
 )
 

--- a/collector/mongod/background_flushing.go
+++ b/collector/mongod/background_flushing.go
@@ -23,13 +23,13 @@ import (
 var (
 	backgroundFlushingflushesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "background_flushing", "flushes_total"),
-		"source = serverStatus backgroundFlushing.flushes",
+		"= serverStatus backgroundFlushing.flushes",
 		nil,
 		nil,
 	)
 	backgroundFlushingtotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "background_flushing", "total_milliseconds"),
-		"source = serverStatus backgroundFlushing.total_ms",
+		"= serverStatus backgroundFlushing.total_ms",
 		nil,
 		nil,
 	)
@@ -37,19 +37,19 @@ var (
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "average_milliseconds",
-		Help:      "source = serverStatus backgroundFlushing.average_ms",
+		Help:      "= serverStatus backgroundFlushing.average_ms",
 	})
 	backgroundFlushinglastMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "last_milliseconds",
-		Help:      "source = serverStatus backgroundFlushing.last_ms",
+		Help:      "= serverStatus backgroundFlushing.last_ms",
 	})
 	backgroundFlushinglastFinishedTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "last_finished_time",
-		Help:      "source = serverStatus backgroundFlushing.last_finished",
+		Help:      "= serverStatus backgroundFlushing.last_finished",
 	})
 )
 

--- a/collector/mongod/collections_status.go
+++ b/collector/mongod/collections_status.go
@@ -15,43 +15,43 @@ var (
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "size",
-		Help:      "The total size in memory of all records in a collection",
+		Help:      "source = collStats size",
 	}, []string{"db", "coll"})
 	collectionObjectCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "count",
-		Help:      "The number of objects or documents in this collection",
+		Help:      "source = collStats count",
 	}, []string{"db", "coll"})
 	collectionAvgObjSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "avgobjsize",
-		Help:      "The average size of an object in the collection (plus any padding)",
+		Help:      "source = collStats avgObjSize",
 	}, []string{"db", "coll"})
 	collectionStorageSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "storage_size",
-		Help:      "The total amount of storage allocated to this collection for document storage",
+		Help:      "source = collStats storageSize",
 	}, []string{"db", "coll"})
 	collectionIndexes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "indexes",
-		Help:      "The number of indexes on the collection",
+		Help:      "source = collStats nindexes",
 	}, []string{"db", "coll"})
 	collectionIndexesSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "indexes_size",
-		Help:      "The total size of all indexes",
+		Help:      "source = collStats totalIndexSize",
 	}, []string{"db", "coll"})
 	collectionIndexSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "index_size",
-		Help:      "The individual index size",
+		Help:      "source = collStats indexSizes",
 	}, []string{"db", "coll", "index"})
 )
 

--- a/collector/mongod/collections_status.go
+++ b/collector/mongod/collections_status.go
@@ -15,43 +15,43 @@ var (
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "size",
-		Help:      "source = collStats size",
+		Help:      "= collStats size",
 	}, []string{"db", "coll"})
 	collectionObjectCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "count",
-		Help:      "source = collStats count",
+		Help:      "= collStats count",
 	}, []string{"db", "coll"})
 	collectionAvgObjSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "avgobjsize",
-		Help:      "source = collStats avgObjSize",
+		Help:      "= collStats avgObjSize",
 	}, []string{"db", "coll"})
 	collectionStorageSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "storage_size",
-		Help:      "source = collStats storageSize",
+		Help:      "= collStats storageSize",
 	}, []string{"db", "coll"})
 	collectionIndexes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "indexes",
-		Help:      "source = collStats nindexes",
+		Help:      "= collStats nindexes",
 	}, []string{"db", "coll"})
 	collectionIndexesSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "indexes_size",
-		Help:      "source = collStats totalIndexSize",
+		Help:      "= collStats totalIndexSize",
 	}, []string{"db", "coll"})
 	collectionIndexSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "index_size",
-		Help:      "source = collStats indexSizes",
+		Help:      "= collStats indexSizes",
 	}, []string{"db", "coll", "index"})
 )
 

--- a/collector/mongod/cursors.go
+++ b/collector/mongod/cursors.go
@@ -19,10 +19,11 @@ import (
 )
 
 var (
+	//N.b. this is not "metrics.cursor.*" this is "cursors.*" which only exists in <= 3.0
 	cursorsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "cursors",
-		Help:      "The cursors data structure contains data regarding cursor state and use",
+		Help:      "source = serverStatus cursors",
 	}, []string{"state"})
 )
 

--- a/collector/mongod/cursors.go
+++ b/collector/mongod/cursors.go
@@ -23,7 +23,7 @@ var (
 	cursorsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "cursors",
-		Help:      "source = serverStatus cursors",
+		Help:      "= serverStatus cursors",
 	}, []string{"state"})
 )
 

--- a/collector/mongod/database_status.go
+++ b/collector/mongod/database_status.go
@@ -14,31 +14,31 @@ var (
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "index_size_bytes",
-		Help:      "source = dbStats indexSize",
+		Help:      "= dbStats indexSize",
 	}, []string{"db"})
 	dataSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "data_size_bytes",
-		Help:      "source = dbStats dataSize",
+		Help:      "= dbStats dataSize",
 	}, []string{"db"})
 	collectionsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "collections_total",
-		Help:      "source = dbStats collections",
+		Help:      "= dbStats collections",
 	}, []string{"db"})
 	indexesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "indexes_total",
-		Help:      "source = dbStats indexes",
+		Help:      "= dbStats indexes",
 	}, []string{"db"})
 	objectsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "objects_total",
-		Help:      "source = dbStats objects",
+		Help:      "= dbStats objects",
 	}, []string{"db"})
 )
 

--- a/collector/mongod/database_status.go
+++ b/collector/mongod/database_status.go
@@ -14,31 +14,31 @@ var (
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "index_size_bytes",
-		Help:      "The total size in bytes of all indexes created on this database",
+		Help:      "source = dbStats indexSize",
 	}, []string{"db"})
 	dataSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "data_size_bytes",
-		Help:      "The total size in bytes of the uncompressed data held in this database",
+		Help:      "source = dbStats dataSize",
 	}, []string{"db"})
 	collectionsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "collections_total",
-		Help:      "Contains a count of the number of collections in that database",
+		Help:      "source = dbStats collections",
 	}, []string{"db"})
 	indexesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "indexes_total",
-		Help:      "Contains a count of the total number of indexes across all collections in the database",
+		Help:      "source = dbStats indexes",
 	}, []string{"db"})
 	objectsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "objects_total",
-		Help:      "Contains a count of the number of objects (i.e. documents) in the database across all collections",
+		Help:      "source = dbStats objects",
 	}, []string{"db"})
 )
 

--- a/collector/mongod/durability.go
+++ b/collector/mongod/durability.go
@@ -22,7 +22,7 @@ var (
 	durabilityCommits = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "durability_commits",
-		Help:      "Durability commits",
+		Help:      "source = serverStatus dur.commits",
 	}, []string{"state"})
 )
 var (
@@ -30,32 +30,32 @@ var (
 		Namespace: Namespace,
 		Subsystem: "durability",
 		Name:      "journaled_megabytes",
-		Help:      "The journaledMB provides the amount of data in megabytes (MB) written to journal during the last journal group commit interval",
+		Help:      "source = serverStatus dur.journaledMB",
 	})
 	durabilityWriteToDataFilesMegabytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "durability",
 		Name:      "write_to_data_files_megabytes",
-		Help:      "The writeToDataFilesMB provides the amount of data in megabytes (MB) written from journal to the data files during the last journal group commit interval",
+		Help:      "source = serverStatus dur.writeToDataFilesMB",
 	})
 	durabilityCompression = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "durability",
 		Name:      "compression",
-		Help:      "The compression represents the compression ratio of the data written to the journal: ( journaled_size_of_data / uncompressed_size_of_data )",
+		Help:      "source = serverStatus dur.compression",
 	})
 	durabilityEarlyCommits = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: Namespace,
 		Subsystem: "durability",
 		Name:      "early_commits",
-		Help:      "The earlyCommits value reflects the number of times MongoDB requested a commit before the scheduled journal group commit interval. Use this value to ensure that your journal group commit interval is not too long for your deployment",
+		Help:      "source = serverStatus dur.earlyCommits",
 	})
 )
 var (
 	durabilityTimeMilliseconds = prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: Namespace,
 		Name:      "durability_time_milliseconds",
-		Help:      "Summary of times spent during the journaling process.",
+		Help:      "source = serverStatus dur.timeMs",
 	}, []string{"stage"})
 )
 

--- a/collector/mongod/durability.go
+++ b/collector/mongod/durability.go
@@ -22,7 +22,7 @@ var (
 	durabilityCommits = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "durability_commits",
-		Help:      "source = serverStatus dur.commits",
+		Help:      "= serverStatus dur.commits",
 	}, []string{"state"})
 )
 var (
@@ -30,32 +30,32 @@ var (
 		Namespace: Namespace,
 		Subsystem: "durability",
 		Name:      "journaled_megabytes",
-		Help:      "source = serverStatus dur.journaledMB",
+		Help:      "= serverStatus dur.journaledMB",
 	})
 	durabilityWriteToDataFilesMegabytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "durability",
 		Name:      "write_to_data_files_megabytes",
-		Help:      "source = serverStatus dur.writeToDataFilesMB",
+		Help:      "= serverStatus dur.writeToDataFilesMB",
 	})
 	durabilityCompression = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "durability",
 		Name:      "compression",
-		Help:      "source = serverStatus dur.compression",
+		Help:      "= serverStatus dur.compression",
 	})
 	durabilityEarlyCommits = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: Namespace,
 		Subsystem: "durability",
 		Name:      "early_commits",
-		Help:      "source = serverStatus dur.earlyCommits",
+		Help:      "= serverStatus dur.earlyCommits",
 	})
 )
 var (
 	durabilityTimeMilliseconds = prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: Namespace,
 		Name:      "durability_time_milliseconds",
-		Help:      "source = serverStatus dur.timeMs",
+		Help:      "= serverStatus dur.timeMs",
 	}, []string{"stage"})
 )
 

--- a/collector/mongod/extra_info.go
+++ b/collector/mongod/extra_info.go
@@ -23,13 +23,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "extra_info",
 		Name:      "page_faults_total",
-		Help:      "source = serverStatus extra_info.page_faults",
+		Help:      "= serverStatus extra_info.page_faults",
 	})
 	extraInfoheapUsageBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "extra_info",
 		Name:      "heap_usage_bytes",
-		Help:      "source = serverStatus extra_info.heap_usage_bytes",
+		Help:      "= serverStatus extra_info.heap_usage_bytes",
 	})
 )
 

--- a/collector/mongod/extra_info.go
+++ b/collector/mongod/extra_info.go
@@ -23,13 +23,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "extra_info",
 		Name:      "page_faults_total",
-		Help:      "The page_faults Reports the total number of page faults that require disk operations. Page faults refer to operations that require the database server to access data which isn’t available in active memory. The page_faults counter may increase dramatically during moments of poor performance and may correlate with limited memory environments and larger data sets. Limited and sporadic page faults do not necessarily indicate an issue",
+		Help:      "source = serverStatus extra_info.page_faults",
 	})
 	extraInfoheapUsageBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "extra_info",
 		Name:      "heap_usage_bytes",
-		Help:      "The heap_usage_bytes field is only available on Unix/Linux systems, and reports the total size in bytes of heap space used by the database process",
+		Help:      "source = serverStatus extra_info.heap_usage_bytes",
 	})
 )
 

--- a/collector/mongod/global_lock.go
+++ b/collector/mongod/global_lock.go
@@ -19,15 +19,16 @@ import (
 )
 
 var (
+	//Deprecated: the lockTime sub-field was removed in MongoDB 3.0
 	globalLockRatio = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "global_lock",
 		Name:      "ratio",
-		Help:      "The value of ratio displays the relationship between lockTime and totalTime. Low values indicate that operations have held the globalLock frequently for shorter periods of time. High values indicate that operations have held globalLock infrequently for longer periods of time",
+		Help:      "source = serverStatus globalLock.lockTime / globalLock.totalTime",
 	})
 	globalLockTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "global_lock", "total"),
-		"The value of totalTime represents the time, in microseconds, since the database last started and creation of the globalLock. This is roughly equivalent to total server uptime",
+		"source = serverStatus globalLock.totalTime",
 		nil,
 		nil,
 	)
@@ -36,14 +37,14 @@ var (
 	globalLockCurrentQueue = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "global_lock_current_queue",
-		Help:      "The currentQueue data structure value provides more granular information concerning the number of operations queued because of a lock",
+		Help:      "source = serverStatus globalLock.currentQueue",
 	}, []string{"type"})
 )
 var (
 	globalLockClient = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "global_lock_client",
-		Help:      "The activeClients data structure provides more granular information about the number of connected clients and the operation types (e.g. read or write) performed by these clients",
+		Help:      "source = serverStatus globalLock.activeClients",
 	}, []string{"type"})
 )
 

--- a/collector/mongod/global_lock.go
+++ b/collector/mongod/global_lock.go
@@ -24,11 +24,11 @@ var (
 		Namespace: Namespace,
 		Subsystem: "global_lock",
 		Name:      "ratio",
-		Help:      "source = serverStatus globalLock.lockTime / globalLock.totalTime",
+		Help:      "= serverStatus globalLock.lockTime / globalLock.totalTime",
 	})
 	globalLockTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "global_lock", "total"),
-		"source = serverStatus globalLock.totalTime",
+		"= serverStatus globalLock.totalTime",
 		nil,
 		nil,
 	)
@@ -37,14 +37,14 @@ var (
 	globalLockCurrentQueue = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "global_lock_current_queue",
-		Help:      "source = serverStatus globalLock.currentQueue",
+		Help:      "= serverStatus globalLock.currentQueue",
 	}, []string{"type"})
 )
 var (
 	globalLockClient = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "global_lock_client",
-		Help:      "source = serverStatus globalLock.activeClients",
+		Help:      "= serverStatus globalLock.activeClients",
 	}, []string{"type"})
 )
 

--- a/collector/mongod/index_counters.go
+++ b/collector/mongod/index_counters.go
@@ -24,7 +24,7 @@ var (
 		Namespace: Namespace,
 		Subsystem: "index_counters",
 		Name:      "miss_ratio",
-		Help:      "source = serverStatus indexCounters.missRatio",
+		Help:      "= serverStatus indexCounters.missRatio",
 	})
 )
 
@@ -32,7 +32,7 @@ var (
 	//This is only present in MongoDB <= 2.6
 	indexCountersTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "index_counters_total"),
-		"source = serverStatus indexCounters (excluding missRatio)",
+		"= serverStatus indexCounters (excluding missRatio)",
 		[]string{"type"},
 		nil,
 	)

--- a/collector/mongod/index_counters.go
+++ b/collector/mongod/index_counters.go
@@ -19,18 +19,20 @@ import (
 )
 
 var (
+	//This is only present in MongoDB <= 2.6
 	indexCountersMissRatio = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "index_counters",
 		Name:      "miss_ratio",
-		Help:      "The missRatio value is the ratio of hits to misses. This value is typically 0 or approaching 0",
+		Help:      "source = serverStatus indexCounters.missRatio",
 	})
 )
 
 var (
+	//This is only present in MongoDB <= 2.6
 	indexCountersTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "index_counters_total"),
-		"Total indexes by type",
+		"source = serverStatus indexCounters (excluding missRatio)",
 		[]string{"type"},
 		nil,
 	)

--- a/collector/mongod/index_usage.go
+++ b/collector/mongod/index_usage.go
@@ -14,7 +14,7 @@ var (
 	indexUsage = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "index_usage_count",
-		Help:      "source = $indexStats(aggregation)",
+		Help:      "= $indexStats(aggregation)",
 	}, []string{"collection", "db", "index"})
 )
 

--- a/collector/mongod/index_usage.go
+++ b/collector/mongod/index_usage.go
@@ -14,7 +14,7 @@ var (
 	indexUsage = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "index_usage_count",
-		Help:      "Contains a usage count of each index",
+		Help:      "source = $indexStats(aggregation)",
 	}, []string{"collection", "db", "index"})
 )
 

--- a/collector/mongod/locks.go
+++ b/collector/mongod/locks.go
@@ -21,7 +21,7 @@ import (
 var (
 	locksTimeLockedGlobalMicrosecondsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "locks_time_locked_global_microseconds_total"),
-		"amount of time in microseconds that any database has held the global lock",
+		"source = serverStatus locks.global.timeLockedMicros",
 		[]string{"type", "database"},
 		nil,
 	)
@@ -29,7 +29,7 @@ var (
 var (
 	locksTimeLockedLocalMicrosecondsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "locks_time_locked_local_microseconds_total"),
-		"amount of time in microseconds that any database has held the local lock",
+		"source = serverStatus locks.local.timeLockedMicros",
 		[]string{"type", "database"},
 		nil,
 	)
@@ -37,7 +37,7 @@ var (
 var (
 	locksTimeAcquiringGlobalMicrosecondsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "locks_time_acquiring_global_microseconds_total"),
-		"amount of time in microseconds that any database has spent waiting for the global lock",
+		"source = serverStatus locks.<database>.timeAcquiringMicros",
 		[]string{"type", "database"},
 		nil,
 	)

--- a/collector/mongod/locks.go
+++ b/collector/mongod/locks.go
@@ -21,7 +21,7 @@ import (
 var (
 	locksTimeLockedGlobalMicrosecondsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "locks_time_locked_global_microseconds_total"),
-		"source = serverStatus locks.global.timeLockedMicros",
+		"= serverStatus locks.global.timeLockedMicros",
 		[]string{"type", "database"},
 		nil,
 	)
@@ -29,7 +29,7 @@ var (
 var (
 	locksTimeLockedLocalMicrosecondsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "locks_time_locked_local_microseconds_total"),
-		"source = serverStatus locks.local.timeLockedMicros",
+		"= serverStatus locks.local.timeLockedMicros",
 		[]string{"type", "database"},
 		nil,
 	)
@@ -37,7 +37,7 @@ var (
 var (
 	locksTimeAcquiringGlobalMicrosecondsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "locks_time_acquiring_global_microseconds_total"),
-		"source = serverStatus locks.<database>.timeAcquiringMicros",
+		"= serverStatus locks.<database>.timeAcquiringMicros",
 		[]string{"type", "database"},
 		nil,
 	)

--- a/collector/mongod/memory.go
+++ b/collector/mongod/memory.go
@@ -22,7 +22,7 @@ var (
 	memory = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "memory",
-		Help:      "source = serverStatus mem",
+		Help:      "= serverStatus mem",
 	}, []string{"type"})
 )
 

--- a/collector/mongod/memory.go
+++ b/collector/mongod/memory.go
@@ -22,7 +22,7 @@ var (
 	memory = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "memory",
-		Help:      "The mem data structure holds information regarding the target system architecture of mongod and current memory use",
+		Help:      "source = serverStatus mem",
 	}, []string{"type"})
 )
 

--- a/collector/mongod/metrics.go
+++ b/collector/mongod/metrics.go
@@ -21,7 +21,7 @@ import (
 var (
 	metricsCursorTimedOutTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_cursor", "timed_out_total"),
-		"timedOut provides the total number of cursors that have timed out since the server process started. If this number is large or growing at a regular rate, this may indicate an application error",
+		"source = serverStatus metrics.cursor.timedOut",
 		nil,
 		nil,
 	)
@@ -30,13 +30,13 @@ var (
 	metricsCursorOpen = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_cursor_open",
-		Help:      "The open is an embedded document that contains data regarding open cursors",
+		Help:      "source = serverStatus metrics.cursor.open",
 	}, []string{"state"})
 )
 var (
 	metricsDocumentTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "metrics_document_total"),
-		"The document holds a document of that reflect document access and modification patterns and data use. Compare these values to the data in the opcounters document, which track total number of operations",
+		"source = serverStatus metrics.document",
 		[]string{"state"},
 		nil,
 	)
@@ -46,11 +46,11 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_get_last_error_wtime",
 		Name:      "num_total",
-		Help:      "num reports the total number of getLastError operations with a specified write concern (i.e. w) that wait for one or more members of a replica set to acknowledge the write operation (i.e. a w value greater than 1.)",
+		Help:      "source = serverStatus metrics.getLastError.wtimeouts",
 	})
 	metricsGetLastErrorWtimeTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_get_last_error_wtime", "total_milliseconds"),
-		"total_millis reports the total amount of time in milliseconds that the mongod has spent performing getLastError operations with write concern (i.e. w) that wait for one or more members of a replica set to acknowledge the write operation (i.e. a w value greater than 1.)",
+		"source = serverStatus metrics.getLastError.wtime.totalMillis",
 		nil,
 		nil,
 	)
@@ -58,7 +58,7 @@ var (
 var (
 	metricsGetLastErrorWtimeoutsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_get_last_error", "wtimeouts_total"),
-		"wtimeouts reports the number of times that write concern operations have timed out as a result of the wtimeout threshold to getLastError.",
+		"source = serverStatus metrics.getLastError.wtime.num",
 		nil,
 		nil,
 	)
@@ -66,7 +66,7 @@ var (
 var (
 	metricsOperationTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "metrics_operation_total"),
-		"operation is a sub-document that holds counters for several types of update and query operations that MongoDB handles using special operation types",
+		"source = serverStatus metrics.operation.scanAndOrder",
 		[]string{"type"},
 		nil,
 	)
@@ -74,7 +74,7 @@ var (
 var (
 	metricsQueryExecutorTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "metrics_query_executor_total"),
-		"queryExecutor is a document that reports data from the query execution system",
+		"source = serverStatus metrics.queryExecutor",
 		[]string{"state"},
 		nil,
 	)
@@ -82,7 +82,7 @@ var (
 var (
 	metricsRecordMovesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_record", "moves_total"),
-		"moves reports the total number of times documents move within the on-disk representation of the MongoDB data set. Documents move as a result of operations that increase the size of the document beyond their allocated record size",
+		"source = serverStatus metrics.record.moves",
 		nil,
 		nil,
 	)
@@ -90,13 +90,13 @@ var (
 var (
 	metricsReplApplyBatchesNumTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_apply_batches", "num_total"),
-		"num reports the total number of batches applied across all databases",
+		"source = serverStatus metrics.repl.apply.batches.num",
 		nil,
 		nil,
 	)
 	metricsReplApplyBatchesTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_apply_batches", "total_milliseconds"),
-		"total_millis reports the total amount of time the mongod has spent applying operations from the oplog",
+		"source = serverStatus metrics.repl.apply.batches.totalMillis",
 		nil,
 		nil,
 	)
@@ -104,7 +104,7 @@ var (
 var (
 	metricsReplApplyOpsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_apply", "ops_total"),
-		"ops reports the total number of oplog operations applied",
+		"source = serverStatus metrics.repl.apply.ops",
 		nil,
 		nil,
 	)
@@ -114,11 +114,11 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_buffer",
 		Name:      "count",
-		Help:      "count reports the current number of operations in the oplog buffer",
+		Help:      "source = serverStatus metrics.repl.buffer.count",
 	})
 	metricsReplBufferMaxSizeBytesDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_buffer", "max_size_bytes"),
-		"maxSizeBytes reports the maximum size of the buffer. This value is a constant setting in the mongod, and is not configurable",
+		"source = serverStatus metrics.repl.buffer.maxSizeBytes",
 		nil,
 		nil,
 	)
@@ -126,13 +126,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_buffer",
 		Name:      "size_bytes",
-		Help:      "sizeBytes reports the current size of the contents of the oplog buffer",
+		Help:      "source = serverStatus metrics.repl.buffer.sizeBytes",
 	})
 )
 var (
 	metricsReplExecutorTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_executor", "total"),
-		"total number of operations in the replication executor",
+		"source = serverStatus metrics.repl.executor.counters",
 		[]string{"type"},
 		nil,
 	)
@@ -140,31 +140,31 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_executor",
 		Name:      "queue",
-		Help:      "number of queued operations in the replication executor",
+		Help:      "source = serverStatus metrics.repl.executor.queues",
 	}, []string{"type"})
 	metricsReplExecutorEventWaiters = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_executor",
 		Name:      "event_waiters",
-		Help:      "number of event waiters in the replication executor",
+		Help:      "source = serverStatus metrics.repl.executor.eventWaiters",
 	})
 	metricsReplExecutorUnsignaledEvents = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_executor",
 		Name:      "unsignaled_events",
-		Help:      "number of unsignaled events in the replication executor",
+		Help:      "source = serverStatus metrics.repl.executor.unsignaledEvents",
 	})
 )
 var (
 	metricsReplNetworkGetmoresNumTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network_getmores", "num_total"),
-		"num reports the total number of getmore operations, which are operations that request an additional set of operations from the replication sync source.",
+		"source = serverStatus metrics.repl.network.getmores.num",
 		nil,
 		nil,
 	)
 	metricsReplNetworkGetmoresTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network_getmores", "total_milliseconds"),
-		"total_millis reports the total amount of time required to collect data from getmore operations",
+		"source = serverStatus metrics.repl.network.getmores.totalMillis",
 		nil,
 		nil,
 	)
@@ -172,19 +172,19 @@ var (
 var (
 	metricsReplNetworkBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network", "bytes_total"),
-		"bytes reports the total amount of data read from the replication sync source",
+		"source = serverStatus metrics.repl.network.bytes",
 		nil,
 		nil,
 	)
 	metricsReplNetworkOpsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network", "ops_total"),
-		"ops reports the total number of operations read from the replication source.",
+		"source = serverStatus metrics.repl.network.ops",
 		nil,
 		nil,
 	)
 	metricsReplNetworkReadersCreatedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network", "readers_created_total"),
-		"readersCreated reports the total number of oplog query processes created. MongoDB will create a new oplog query any time an error occurs in the connection, including a timeout, or a network operation. Furthermore, readersCreated will increment every time MongoDB selects a new source fore replication.",
+		"source = serverStatus metrics.repl.network.readersCreated",
 		nil,
 		nil,
 	)
@@ -194,13 +194,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_oplog_insert",
 		Name:      "num_total",
-		Help:      "num reports the total number of items inserted into the oplog.",
+		Help:      "source = serverStatus metrics.repl.oplog.insert.num",
 	})
 	metricsReplOplogInsertTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_oplog_insert",
 		Name:      "total_milliseconds",
-		Help:      "total_millis reports the total amount of time spent for the mongod to insert data into the oplog.",
+		Help:      "source = serverStatus metrics.repl.oplog.insert.totalMillis",
 	})
 )
 var (
@@ -208,19 +208,19 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_oplog",
 		Name:      "insert_bytes_total",
-		Help:      "insertBytes the total size of documents inserted into the oplog.",
+		Help:      "source = serverStatus metrics.repl.oplog.insertBytes",
 	})
 )
 var (
 	metricsReplPreloadDocsNumTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_preload_docs", "num_total"),
-		"num reports the total number of documents loaded during the pre-fetch stage of replication",
+		"source = serverStatus metrics.repl.preload.num.docs.num",
 		nil,
 		nil,
 	)
 	metricsReplPreloadDocsTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_preload_docs", "total_milliseconds"),
-		"total_millis reports the total amount of time spent loading documents as part of the pre-fetch stage of replication",
+		"source = serverStatus metrics.repl.preload.num.docs.totalMillis",
 		nil,
 		nil,
 	)
@@ -228,13 +228,13 @@ var (
 var (
 	metricsReplPreloadIndexesNumTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_preload_indexes", "num_total"),
-		"num reports the total number of index entries loaded by members before updating documents as part of the pre-fetch stage of replication",
+		"source = serverStatus metrics.repl.preload.num.indexes.num",
 		nil,
 		nil,
 	)
 	metricsReplPreloadIndexesTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_preload_indexes", "total_milliseconds"),
-		"total_millis reports the total amount of time spent loading index entries as part of the pre-fetch stage of replication",
+		"source = serverStatus metrics.repl.preload.num.indexes.totalMillis",
 		nil,
 		nil,
 	)
@@ -242,7 +242,7 @@ var (
 var (
 	metricsStorageFreelistSearchTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "metrics_storage_freelist_search_total"),
-		"metrics about searching records in the database.",
+		"source = serverStatus metrics.storage.freelist.search",
 		[]string{"type"},
 		nil,
 	)
@@ -250,13 +250,13 @@ var (
 var (
 	metricsTTLDeletedDocumentsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_ttl", "deleted_documents_total"),
-		"deletedDocuments reports the total number of documents deleted from collections with a ttl index.",
+		"source = serverStatus metrics.ttl.deletedDocuments",
 		nil,
 		nil,
 	)
 	metricsTTLPassesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_ttl", "passes_total"),
-		"passes reports the number of times the background process removes documents from collections with a ttl index",
+		"source = serverStatus metrics.ttl.passes",
 		nil,
 		nil,
 	)

--- a/collector/mongod/metrics.go
+++ b/collector/mongod/metrics.go
@@ -21,7 +21,7 @@ import (
 var (
 	metricsCursorTimedOutTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_cursor", "timed_out_total"),
-		"source = serverStatus metrics.cursor.timedOut",
+		"= serverStatus metrics.cursor.timedOut",
 		nil,
 		nil,
 	)
@@ -30,13 +30,13 @@ var (
 	metricsCursorOpen = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_cursor_open",
-		Help:      "source = serverStatus metrics.cursor.open",
+		Help:      "= serverStatus metrics.cursor.open",
 	}, []string{"state"})
 )
 var (
 	metricsDocumentTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "metrics_document_total"),
-		"source = serverStatus metrics.document",
+		"= serverStatus metrics.document",
 		[]string{"state"},
 		nil,
 	)
@@ -46,11 +46,11 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_get_last_error_wtime",
 		Name:      "num_total",
-		Help:      "source = serverStatus metrics.getLastError.wtimeouts",
+		Help:      "= serverStatus metrics.getLastError.wtimeouts",
 	})
 	metricsGetLastErrorWtimeTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_get_last_error_wtime", "total_milliseconds"),
-		"source = serverStatus metrics.getLastError.wtime.totalMillis",
+		"= serverStatus metrics.getLastError.wtime.totalMillis",
 		nil,
 		nil,
 	)
@@ -58,7 +58,7 @@ var (
 var (
 	metricsGetLastErrorWtimeoutsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_get_last_error", "wtimeouts_total"),
-		"source = serverStatus metrics.getLastError.wtime.num",
+		"= serverStatus metrics.getLastError.wtime.num",
 		nil,
 		nil,
 	)
@@ -66,7 +66,7 @@ var (
 var (
 	metricsOperationTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "metrics_operation_total"),
-		"source = serverStatus metrics.operation.scanAndOrder",
+		"= serverStatus metrics.operation.scanAndOrder",
 		[]string{"type"},
 		nil,
 	)
@@ -74,7 +74,7 @@ var (
 var (
 	metricsQueryExecutorTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "metrics_query_executor_total"),
-		"source = serverStatus metrics.queryExecutor",
+		"= serverStatus metrics.queryExecutor",
 		[]string{"state"},
 		nil,
 	)
@@ -82,7 +82,7 @@ var (
 var (
 	metricsRecordMovesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_record", "moves_total"),
-		"source = serverStatus metrics.record.moves",
+		"= serverStatus metrics.record.moves",
 		nil,
 		nil,
 	)
@@ -90,13 +90,13 @@ var (
 var (
 	metricsReplApplyBatchesNumTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_apply_batches", "num_total"),
-		"source = serverStatus metrics.repl.apply.batches.num",
+		"= serverStatus metrics.repl.apply.batches.num",
 		nil,
 		nil,
 	)
 	metricsReplApplyBatchesTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_apply_batches", "total_milliseconds"),
-		"source = serverStatus metrics.repl.apply.batches.totalMillis",
+		"= serverStatus metrics.repl.apply.batches.totalMillis",
 		nil,
 		nil,
 	)
@@ -104,7 +104,7 @@ var (
 var (
 	metricsReplApplyOpsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_apply", "ops_total"),
-		"source = serverStatus metrics.repl.apply.ops",
+		"= serverStatus metrics.repl.apply.ops",
 		nil,
 		nil,
 	)
@@ -114,11 +114,11 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_buffer",
 		Name:      "count",
-		Help:      "source = serverStatus metrics.repl.buffer.count",
+		Help:      "= serverStatus metrics.repl.buffer.count",
 	})
 	metricsReplBufferMaxSizeBytesDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_buffer", "max_size_bytes"),
-		"source = serverStatus metrics.repl.buffer.maxSizeBytes",
+		"= serverStatus metrics.repl.buffer.maxSizeBytes",
 		nil,
 		nil,
 	)
@@ -126,13 +126,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_buffer",
 		Name:      "size_bytes",
-		Help:      "source = serverStatus metrics.repl.buffer.sizeBytes",
+		Help:      "= serverStatus metrics.repl.buffer.sizeBytes",
 	})
 )
 var (
 	metricsReplExecutorTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_executor", "total"),
-		"source = serverStatus metrics.repl.executor.counters",
+		"= serverStatus metrics.repl.executor.counters",
 		[]string{"type"},
 		nil,
 	)
@@ -140,31 +140,31 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_executor",
 		Name:      "queue",
-		Help:      "source = serverStatus metrics.repl.executor.queues",
+		Help:      "= serverStatus metrics.repl.executor.queues",
 	}, []string{"type"})
 	metricsReplExecutorEventWaiters = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_executor",
 		Name:      "event_waiters",
-		Help:      "source = serverStatus metrics.repl.executor.eventWaiters",
+		Help:      "= serverStatus metrics.repl.executor.eventWaiters",
 	})
 	metricsReplExecutorUnsignaledEvents = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_executor",
 		Name:      "unsignaled_events",
-		Help:      "source = serverStatus metrics.repl.executor.unsignaledEvents",
+		Help:      "= serverStatus metrics.repl.executor.unsignaledEvents",
 	})
 )
 var (
 	metricsReplNetworkGetmoresNumTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network_getmores", "num_total"),
-		"source = serverStatus metrics.repl.network.getmores.num",
+		"= serverStatus metrics.repl.network.getmores.num",
 		nil,
 		nil,
 	)
 	metricsReplNetworkGetmoresTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network_getmores", "total_milliseconds"),
-		"source = serverStatus metrics.repl.network.getmores.totalMillis",
+		"= serverStatus metrics.repl.network.getmores.totalMillis",
 		nil,
 		nil,
 	)
@@ -172,19 +172,19 @@ var (
 var (
 	metricsReplNetworkBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network", "bytes_total"),
-		"source = serverStatus metrics.repl.network.bytes",
+		"= serverStatus metrics.repl.network.bytes",
 		nil,
 		nil,
 	)
 	metricsReplNetworkOpsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network", "ops_total"),
-		"source = serverStatus metrics.repl.network.ops",
+		"= serverStatus metrics.repl.network.ops",
 		nil,
 		nil,
 	)
 	metricsReplNetworkReadersCreatedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_network", "readers_created_total"),
-		"source = serverStatus metrics.repl.network.readersCreated",
+		"= serverStatus metrics.repl.network.readersCreated",
 		nil,
 		nil,
 	)
@@ -194,13 +194,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_oplog_insert",
 		Name:      "num_total",
-		Help:      "source = serverStatus metrics.repl.oplog.insert.num",
+		Help:      "= serverStatus metrics.repl.oplog.insert.num",
 	})
 	metricsReplOplogInsertTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_oplog_insert",
 		Name:      "total_milliseconds",
-		Help:      "source = serverStatus metrics.repl.oplog.insert.totalMillis",
+		Help:      "= serverStatus metrics.repl.oplog.insert.totalMillis",
 	})
 )
 var (
@@ -208,19 +208,19 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_oplog",
 		Name:      "insert_bytes_total",
-		Help:      "source = serverStatus metrics.repl.oplog.insertBytes",
+		Help:      "= serverStatus metrics.repl.oplog.insertBytes",
 	})
 )
 var (
 	metricsReplPreloadDocsNumTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_preload_docs", "num_total"),
-		"source = serverStatus metrics.repl.preload.num.docs.num",
+		"= serverStatus metrics.repl.preload.num.docs.num",
 		nil,
 		nil,
 	)
 	metricsReplPreloadDocsTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_preload_docs", "total_milliseconds"),
-		"source = serverStatus metrics.repl.preload.num.docs.totalMillis",
+		"= serverStatus metrics.repl.preload.num.docs.totalMillis",
 		nil,
 		nil,
 	)
@@ -228,13 +228,13 @@ var (
 var (
 	metricsReplPreloadIndexesNumTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_preload_indexes", "num_total"),
-		"source = serverStatus metrics.repl.preload.num.indexes.num",
+		"= serverStatus metrics.repl.preload.num.indexes.num",
 		nil,
 		nil,
 	)
 	metricsReplPreloadIndexesTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_repl_preload_indexes", "total_milliseconds"),
-		"source = serverStatus metrics.repl.preload.num.indexes.totalMillis",
+		"= serverStatus metrics.repl.preload.num.indexes.totalMillis",
 		nil,
 		nil,
 	)
@@ -242,7 +242,7 @@ var (
 var (
 	metricsStorageFreelistSearchTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "metrics_storage_freelist_search_total"),
-		"source = serverStatus metrics.storage.freelist.search",
+		"= serverStatus metrics.storage.freelist.search",
 		[]string{"type"},
 		nil,
 	)
@@ -250,13 +250,13 @@ var (
 var (
 	metricsTTLDeletedDocumentsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_ttl", "deleted_documents_total"),
-		"source = serverStatus metrics.ttl.deletedDocuments",
+		"= serverStatus metrics.ttl.deletedDocuments",
 		nil,
 		nil,
 	)
 	metricsTTLPassesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_ttl", "passes_total"),
-		"source = serverStatus metrics.ttl.passes",
+		"= serverStatus metrics.ttl.passes",
 		nil,
 		nil,
 	)

--- a/collector/mongod/metrics.go
+++ b/collector/mongod/metrics.go
@@ -66,7 +66,7 @@ var (
 var (
 	metricsOperationTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "metrics_operation_total"),
-		"= serverStatus metrics.operation.scanAndOrder",
+		"= serverStatus metrics.operation.[fastmod|idhack|scanAndOrder]",
 		[]string{"type"},
 		nil,
 	)

--- a/collector/mongod/op_latencies.go
+++ b/collector/mongod/op_latencies.go
@@ -23,19 +23,19 @@ var (
 	opLatenciesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_latencies_latency_total",
-		Help:      "source = serverStatus opLatencies.*.latency",
+		Help:      "= serverStatus opLatencies.*.latency",
 	}, []string{"type"})
 
 	opLatenciesCountTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_latencies_ops_total",
-		Help:      "source = serverStatus opLatencies.*.ops",
+		Help:      "= serverStatus opLatencies.*.ops",
 	}, []string{"type"})
 
 	opLatenciesHistogram = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_latencies_histogram",
-		Help:      "source = serverStatus opLatencies.*.histogram",
+		Help:      "= serverStatus opLatencies.*.histogram",
 	}, []string{"type", "micros"})
 )
 

--- a/collector/mongod/op_latencies.go
+++ b/collector/mongod/op_latencies.go
@@ -23,19 +23,19 @@ var (
 	opLatenciesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_latencies_latency_total",
-		Help:      "op latencies statistics in microseconds of mongod",
+		Help:      "source = serverStatus opLatencies.*.latency",
 	}, []string{"type"})
 
 	opLatenciesCountTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_latencies_ops_total",
-		Help:      "op latencies ops total statistics of mongod",
+		Help:      "source = serverStatus opLatencies.*.ops",
 	}, []string{"type"})
 
 	opLatenciesHistogram = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_latencies_histogram",
-		Help:      "op latencies histogram statistics of mongod",
+		Help:      "source = serverStatus opLatencies.*.histogram",
 	}, []string{"type", "micros"})
 )
 

--- a/collector/mongod/oplog_status.go
+++ b/collector/mongod/oplog_status.go
@@ -34,25 +34,25 @@ var (
 		Namespace: Namespace,
 		Subsystem: "replset_oplog",
 		Name:      "items_total",
-		Help:      "source = collStats count",
+		Help:      "= collStats count",
 	})
 	oplogStatusHeadTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "replset_oplog",
 		Name:      "head_timestamp",
-		Help:      "source = local.oplog.rs (findOne oldest)",
+		Help:      "= local.oplog.rs (findOne oldest)",
 	})
 	oplogStatusTailTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "replset_oplog",
 		Name:      "tail_timestamp",
-		Help:      "source = local.oplog.rs (findOne latest)",
+		Help:      "= local.oplog.rs (findOne latest)",
 	})
 	oplogStatusSizeBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "replset_oplog",
 		Name:      "size_bytes",
-		Help:      "source = collStats size, storageSize",
+		Help:      "= collStats size, storageSize",
 	}, []string{"type"})
 )
 

--- a/collector/mongod/oplog_status.go
+++ b/collector/mongod/oplog_status.go
@@ -34,25 +34,25 @@ var (
 		Namespace: Namespace,
 		Subsystem: "replset_oplog",
 		Name:      "items_total",
-		Help:      "The total number of changes in the oplog",
+		Help:      "source = collStats count",
 	})
 	oplogStatusHeadTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "replset_oplog",
 		Name:      "head_timestamp",
-		Help:      "The timestamp of the newest change in the oplog",
+		Help:      "source = local.oplog.rs (findOne oldest)",
 	})
 	oplogStatusTailTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "replset_oplog",
 		Name:      "tail_timestamp",
-		Help:      "The timestamp of the oldest change in the oplog",
+		Help:      "source = local.oplog.rs (findOne latest)",
 	})
 	oplogStatusSizeBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "replset_oplog",
 		Name:      "size_bytes",
-		Help:      "Size of oplog in bytes",
+		Help:      "source = collStats size, storageSize",
 	}, []string{"type"})
 )
 

--- a/collector/mongod/replset_conf.go
+++ b/collector/mongod/replset_conf.go
@@ -12,35 +12,35 @@ import (
 var (
 	memberHiddenDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, subsystem, "member_hidden"),
-		"This field conveys if the member is hidden (1) or not-hidden (0).",
+		"= replSetGetConfig members.*.hidden",
 		[]string{"id", "host"},
 		nil,
 	)
 
 	memberArbiterDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, subsystem, "member_arbiter"),
-		"This field conveys if the member is an arbiter (1) or not (0).",
+		"= replSetGetConfig members.*.arbiter",
 		[]string{"id", "host"},
 		nil,
 	)
 
 	memberBuildIndexesDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, subsystem, "member_build_indexes"),
-		"This field conveys if the member is  builds indexes (1) or not (0).",
+		"= replSetGetConfig members.*.buildIndexes",
 		[]string{"id", "host"},
 		nil,
 	)
 
 	memberPriorityDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, subsystem, "member_priority"),
-		"This field conveys the priority of a given member",
+		"= replSetGetConfig members.*.priority",
 		[]string{"id", "host"},
 		nil,
 	)
 
 	memberVotesDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, subsystem, "member_votes"),
-		"This field conveys the number of votes of a given member",
+		"= replSetGetConfig members.*.votes",
 		[]string{"id", "host"},
 		nil,
 	)

--- a/collector/mongod/replset_status.go
+++ b/collector/mongod/replset_status.go
@@ -31,53 +31,53 @@ var (
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "my_name",
-		Help:      "The replica state name of the current member",
+		Help:      "source = replSetGetStatus members.*.name (where self=true)",
 	}, []string{"set", "name"})
 	myState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "my_state",
-		Help:      "An integer between 0 and 10 that represents the replica state of the current member",
+		Help:      "source = replSetGetStatus myState",
 	}, []string{"set"})
 	date = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "date",
-		Help:      "The value of the date field is an ISODate of the current time, according to the current server.",
+		Help:      "source = replSetGetStatus date",
 	}, []string{"set"})
 	term = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "term",
-		Help:      "The election count for the replica set, as known to this replica set member",
+		Help:      "source = replSetGetStatus term",
 	}, []string{"set"})
 	numberOfMembers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "number_of_members",
-		Help:      "The number of replica set mebers",
+		Help:      "source = replSetGetStatus members",
 	}, []string{"set"})
 	heartbeatIntervalMillis = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "heatbeat_interval_millis",
-		Help:      "The frequency in milliseconds of the heartbeats",
+		Help:      "source = replSetGetStatus heartbeatIntervalMillis",
 	}, []string{"set"})
 	memberHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_health",
-		Help:      "This field conveys if the member is up (1) or down (0).",
+		Help:      "source = replSetGetStatus members.*.health",
 	}, []string{"set", "name", "state"})
 	memberState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_state",
-		Help:      "The value of state is an integer between 0 and 10 that represents the replica state of the member.",
+		Help:      "source = replSetGetStatus members.*.state",
 	}, []string{"set", "name", "state"})
 	memberUptimeDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, subsystem, "member_uptime"),
-		"The uptime field holds a value that reflects the number of seconds that this member has been online.",
+		"source = replSetGetStatus members.*.uptime",
 		[]string{"set", "name", "state"},
 		nil,
 	)
@@ -85,49 +85,49 @@ var (
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_optime_date",
-		Help:      "The timestamp of the last oplog entry that this member applied.",
+		Help:      "source = replSetGetStatus members.*.optimeDate",
 	}, []string{"set", "name", "state"})
 	memberRepLag = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_replication_lag",
-		Help:      "The replication lag that this member has with the primary.",
+		Help:      "source = replSetGetStatus members.*.optimeDate (primary's minus current member)",
 	}, []string{"set", "name", "state"})
 	memberOperationalLag = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_operational_lag",
-		Help:      "The operationl lag - or staleness of the oplog timestamp - for this member.",
+		Help:      "source = current unix time minus replSetGetStatus members.*.lastHeartbeatRecv (Unix time is of mongodb_exporter's host, which is assumed to be same as monitored mongod)",
 	}, []string{"set", "name", "state"})
 	memberElectionDate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_election_date",
-		Help:      "The timestamp the node was elected as replica leader",
+		Help:      "source = replSetGetStatus members.*.electionDate",
 	}, []string{"set", "name", "state"})
 	memberLastHeartbeat = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_last_heartbeat",
-		Help:      "The lastHeartbeat value provides an ISODate formatted date and time of the transmission time of last heartbeat received from this member",
+		Help:      "source = replSetGetStatus members.*.lastHeartbeat",
 	}, []string{"set", "name", "state"})
 	memberLastHeartbeatRecv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_last_heartbeat_recv",
-		Help:      "The lastHeartbeatRecv value provides an ISODate formatted date and time that the last heartbeat was received from this member",
+		Help:      "source = replSetGetStatus members.*.lastHeartbeatRecv",
 	}, []string{"set", "name", "state"})
 	memberPingMs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_ping_ms",
-		Help:      "The pingMs represents the number of milliseconds (ms) that a round-trip packet takes to travel between the remote member and the local instance.",
+		Help:      "source = replSetGetStatus members.*.pingMs",
 	}, []string{"set", "name", "state"})
 	memberConfigVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_config_version",
-		Help:      "The configVersion value is the replica set configuration version.",
+		Help:      "source = replSetGetStatus members.*.configVersion",
 	}, []string{"set", "name", "state"})
 	primaryOptimeDate        float64
 	primaryLastHeartbeatRecv float64

--- a/collector/mongod/replset_status.go
+++ b/collector/mongod/replset_status.go
@@ -31,53 +31,53 @@ var (
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "my_name",
-		Help:      "source = replSetGetStatus members.*.name (where self=true)",
+		Help:      "= replSetGetStatus members.*.name (where self=true)",
 	}, []string{"set", "name"})
 	myState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "my_state",
-		Help:      "source = replSetGetStatus myState",
+		Help:      "= replSetGetStatus myState",
 	}, []string{"set"})
 	date = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "date",
-		Help:      "source = replSetGetStatus date",
+		Help:      "= replSetGetStatus date",
 	}, []string{"set"})
 	term = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "term",
-		Help:      "source = replSetGetStatus term",
+		Help:      "= replSetGetStatus term",
 	}, []string{"set"})
 	numberOfMembers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "number_of_members",
-		Help:      "source = replSetGetStatus members",
+		Help:      "= replSetGetStatus members",
 	}, []string{"set"})
 	heartbeatIntervalMillis = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "heatbeat_interval_millis",
-		Help:      "source = replSetGetStatus heartbeatIntervalMillis",
+		Help:      "= replSetGetStatus heartbeatIntervalMillis",
 	}, []string{"set"})
 	memberHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_health",
-		Help:      "source = replSetGetStatus members.*.health",
+		Help:      "= replSetGetStatus members.*.health",
 	}, []string{"set", "name", "state"})
 	memberState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_state",
-		Help:      "source = replSetGetStatus members.*.state",
+		Help:      "= replSetGetStatus members.*.state",
 	}, []string{"set", "name", "state"})
 	memberUptimeDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, subsystem, "member_uptime"),
-		"source = replSetGetStatus members.*.uptime",
+		"= replSetGetStatus members.*.uptime",
 		[]string{"set", "name", "state"},
 		nil,
 	)
@@ -85,49 +85,49 @@ var (
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_optime_date",
-		Help:      "source = replSetGetStatus members.*.optimeDate",
+		Help:      "= replSetGetStatus members.*.optimeDate",
 	}, []string{"set", "name", "state"})
 	memberRepLag = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_replication_lag",
-		Help:      "source = replSetGetStatus members.*.optimeDate (primary's minus current member)",
+		Help:      "= replSetGetStatus members.*.optimeDate (primary's minus current member)",
 	}, []string{"set", "name", "state"})
 	memberOperationalLag = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_operational_lag",
-		Help:      "source = current unix time minus replSetGetStatus members.*.lastHeartbeatRecv (Unix time is of mongodb_exporter's host, which is assumed to be same as monitored mongod)",
+		Help:      "= current unix time minus replSetGetStatus members.*.lastHeartbeatRecv (Unix time is of mongodb_exporter's host, which is assumed to be same as monitored mongod)",
 	}, []string{"set", "name", "state"})
 	memberElectionDate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_election_date",
-		Help:      "source = replSetGetStatus members.*.electionDate",
+		Help:      "= replSetGetStatus members.*.electionDate",
 	}, []string{"set", "name", "state"})
 	memberLastHeartbeat = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_last_heartbeat",
-		Help:      "source = replSetGetStatus members.*.lastHeartbeat",
+		Help:      "= replSetGetStatus members.*.lastHeartbeat",
 	}, []string{"set", "name", "state"})
 	memberLastHeartbeatRecv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_last_heartbeat_recv",
-		Help:      "source = replSetGetStatus members.*.lastHeartbeatRecv",
+		Help:      "= replSetGetStatus members.*.lastHeartbeatRecv",
 	}, []string{"set", "name", "state"})
 	memberPingMs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_ping_ms",
-		Help:      "source = replSetGetStatus members.*.pingMs",
+		Help:      "= replSetGetStatus members.*.pingMs",
 	}, []string{"set", "name", "state"})
 	memberConfigVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_config_version",
-		Help:      "source = replSetGetStatus members.*.configVersion",
+		Help:      "= replSetGetStatus members.*.configVersion",
 	}, []string{"set", "name", "state"})
 	primaryOptimeDate        float64
 	primaryLastHeartbeatRecv float64

--- a/collector/mongod/storage_engine.go
+++ b/collector/mongod/storage_engine.go
@@ -21,7 +21,7 @@ import (
 var (
 	storageEngineDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "storage_engine"),
-		"source = serverStatus storageEngine.name",
+		"= serverStatus storageEngine.name",
 		[]string{"engine"},
 		nil,
 	)

--- a/collector/mongod/storage_engine.go
+++ b/collector/mongod/storage_engine.go
@@ -21,7 +21,7 @@ import (
 var (
 	storageEngineDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "storage_engine"),
-		"The storage engine used by the MongoDB instance",
+		"source = serverStatus storageEngine.name",
 		[]string{"engine"},
 		nil,
 	)

--- a/collector/mongod/top_counters.go
+++ b/collector/mongod/top_counters.go
@@ -10,13 +10,13 @@ import (
 var (
 	topCountTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "top_count_total"),
-		"The top command provides operation count for each database collection",
+		"= top totals.<db_and_coll_name>.*.count",
 		[]string{"type", "database", "collection"}, nil,
 	)
 
 	topTimeSecondsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "top_time_seconds_total"),
-		"The top command provides operation time, in seconds, for each database collection",
+		"= top totals.<db_and_coll_name>.*.time",
 		[]string{"type", "database", "collection"}, nil,
 	)
 )

--- a/collector/mongod/wiredtiger.go
+++ b/collector/mongod/wiredtiger.go
@@ -21,13 +21,13 @@ import (
 var (
 	wtBlockManagerBlocksTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_blockmanager", "blocks_total"),
-		"source = serverStatus wiredTiger.block-manager.[\"mapped blocks read\"|\"blocks pre-loaded\"|\"blocks read\"|\"blocks written\"]",
+		"= serverStatus wiredTiger.block-manager.[\"mapped blocks read\"|\"blocks pre-loaded\"|\"blocks read\"|\"blocks written\"]",
 		[]string{"type"},
 		nil,
 	)
 	wtBlockManagerBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_blockmanager", "bytes_total"),
-		"source = serverStatus wiredTiger.block-manager.[\"mapped bytes read\"|\"bytes read\"|\"bytes written\"]",
+		"= serverStatus wiredTiger.block-manager.[\"mapped bytes read\"|\"bytes read\"|\"bytes written\"]",
 		[]string{"type"},
 		nil,
 	)
@@ -38,11 +38,11 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "pages",
-		Help:      "source = serverStatus wiredTiger.cache",
+		Help:      "= serverStatus wiredTiger.cache",
 	}, []string{"type"})
 	wtCachePagesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_cache", "pages_total"),
-		"source = serverStatus wiredTiger.cache.\"pages currently held in the cache\"",
+		"= serverStatus wiredTiger.cache.\"pages currently held in the cache\"",
 		[]string{"type"},
 		nil,
 	)
@@ -50,23 +50,23 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "bytes",
-		Help:      "source = serverStatus wiredTiger.cache.\"bytes currently in the cache\"",
+		Help:      "= serverStatus wiredTiger.cache.\"bytes currently in the cache\"",
 	}, []string{"type"})
 	wtCacheMaxBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "max_bytes",
-		Help:      "source = serverStatus wiredTiger.cache.\"maximum bytes configured\"",
+		Help:      "= serverStatus wiredTiger.cache.\"maximum bytes configured\"",
 	})
 	wtCacheBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_cache", "bytes_total"),
-		"source = serverStatus wiredTiger.cache.[\"bytes read into cache\"|\"bytes written from cache\"]",
+		"= serverStatus wiredTiger.cache.[\"bytes read into cache\"|\"bytes written from cache\"]",
 		[]string{"type"},
 		nil,
 	)
 	wtCacheEvictedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_cache", "evicted_total"),
-		"source = serverStatus wiredTiger.cache.[\"modified pages evicted\"|\"unmodified pages evicted\"]",
+		"= serverStatus wiredTiger.cache.[\"modified pages evicted\"|\"unmodified pages evicted\"]",
 		[]string{"type"},
 		nil,
 	)
@@ -74,20 +74,20 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "overhead_percent",
-		Help:      "source = serverStatus wiredTiger.cache.\"percentage overhead\"",
+		Help:      "= serverStatus wiredTiger.cache.\"percentage overhead\"",
 	})
 )
 
 var (
 	wtTransactionsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_transactions", "total"),
-		"source = serverStatus wiredTiger.transactions",
+		"= serverStatus wiredTiger.transactions",
 		[]string{"type"},
 		nil,
 	)
 	wtTransactionsTotalCheckpointMsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_transactions", "checkpoint_milliseconds_total"),
-		"source = serverStatus wiredTiger.transactions.\"transaction checkpoint *\"",
+		"= serverStatus wiredTiger.transactions.\"transaction checkpoint *\"",
 		nil,
 		nil,
 	)
@@ -95,38 +95,38 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_transactions",
 		Name:      "checkpoint_milliseconds",
-		Help:      "source = serverStatus wiredTiger.transactions.\"transaction checkpoint [min|max] time (msecs)\"",
+		Help:      "= serverStatus wiredTiger.transactions.\"transaction checkpoint [min|max] time (msecs)\"",
 	}, []string{"type"})
 	wtTransactionsCheckpointsRunning = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_transactions",
 		Name:      "running_checkpoints",
-		Help:      "source = serverStatus wiredTiger.transactions.\"transaction checkpoint currently running\"",
+		Help:      "= serverStatus wiredTiger.transactions.\"transaction checkpoint currently running\"",
 	})
 )
 
 var (
 	wtLogRecordsScannedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_log", "records_scanned_total"),
-		"source = serverStatus wiredTiger.log.\"records processed by log scan\"",
+		"= serverStatus wiredTiger.log.\"records processed by log scan\"",
 		nil,
 		nil,
 	)
 	wtLogRecordsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_log", "records_total"),
-		"source = serverStatus wiredTiger.log.[\"log records not compressed\"|\"log records compressed\"]",
+		"= serverStatus wiredTiger.log.[\"log records not compressed\"|\"log records compressed\"]",
 		[]string{"type"},
 		nil,
 	)
 	wtLogBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_log", "bytes_total"),
-		"source = serverStatus wiredTiger.log.[\"log bytes of payload data\"|\"log bytes written\"]",
+		"= serverStatus wiredTiger.log.[\"log bytes of payload data\"|\"log bytes written\"]",
 		[]string{"type"},
 		nil,
 	)
 	wtLogOperationsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_log", "operations_total"),
-		"source = serverStatus wiredTiger.log.[\"log [flush|read|scan|sync|sync_dir|write] operations\"|\"log scan records requiring two reads\"]",
+		"= serverStatus wiredTiger.log.[\"log [flush|read|scan|sync|sync_dir|write] operations\"|\"log scan records requiring two reads\"]",
 		[]string{"type"},
 		nil,
 	)
@@ -137,13 +137,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_session",
 		Name:      "open_cursors_total",
-		Help:      "source = serverStatus wiredTiger.\"open cursor count\"",
+		Help:      "= serverStatus wiredTiger.\"open cursor count\"",
 	})
 	wtOpenSessions = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_session",
 		Name:      "open_sessions_total",
-		Help:      "source = serverStatus wiredTiger.\"open session count\"",
+		Help:      "= serverStatus wiredTiger.\"open session count\"",
 	})
 )
 
@@ -152,19 +152,19 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_concurrent_transactions",
 		Name:      "out_tickets",
-		Help:      "source = serverStatus wiredTiger.concurrentTransactions.*.out",
+		Help:      "= serverStatus wiredTiger.concurrentTransactions.*.out",
 	}, []string{"type"})
 	wtConcurrentTransactionsAvailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_concurrent_transactions",
 		Name:      "available_tickets",
-		Help:      "source = serverStatus wiredTiger.concurrentTransactions.*.available",
+		Help:      "= serverStatus wiredTiger.concurrentTransactions.*.available",
 	}, []string{"type"})
 	wtConcurrentTransactionsTotalTickets = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_concurrent_transactions",
 		Name:      "total_tickets",
-		Help:      "source = serverStatus wiredTiger.concurrentTransactions.*.totalTickets",
+		Help:      "= serverStatus wiredTiger.concurrentTransactions.*.totalTickets",
 	}, []string{"type"})
 )
 

--- a/collector/mongod/wiredtiger.go
+++ b/collector/mongod/wiredtiger.go
@@ -21,13 +21,13 @@ import (
 var (
 	wtBlockManagerBlocksTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_blockmanager", "blocks_total"),
-		"The total number of blocks read by the WiredTiger BlockManager",
+		"source = serverStatus wiredTiger.block-manager.[\"mapped blocks read\"|\"blocks pre-loaded\"|\"blocks read\"|\"blocks written\"]",
 		[]string{"type"},
 		nil,
 	)
 	wtBlockManagerBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_blockmanager", "bytes_total"),
-		"The total number of bytes read by the WiredTiger BlockManager",
+		"source = serverStatus wiredTiger.block-manager.[\"mapped bytes read\"|\"bytes read\"|\"bytes written\"]",
 		[]string{"type"},
 		nil,
 	)
@@ -38,11 +38,11 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "pages",
-		Help:      "The current number of pages in the WiredTiger Cache",
+		Help:      "source = serverStatus wiredTiger.cache",
 	}, []string{"type"})
 	wtCachePagesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_cache", "pages_total"),
-		"The total number of pages read into/from the WiredTiger Cache",
+		"source = serverStatus wiredTiger.cache.\"pages currently held in the cache\"",
 		[]string{"type"},
 		nil,
 	)
@@ -50,23 +50,23 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "bytes",
-		Help:      "The current size of data in the WiredTiger Cache in bytes",
+		Help:      "source = serverStatus wiredTiger.cache.\"bytes currently in the cache\"",
 	}, []string{"type"})
 	wtCacheMaxBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "max_bytes",
-		Help:      "The maximum size of data in the WiredTiger Cache in bytes",
+		Help:      "source = serverStatus wiredTiger.cache.\"maximum bytes configured\"",
 	})
 	wtCacheBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_cache", "bytes_total"),
-		"The total number of bytes read into/from the WiredTiger Cache",
+		"source = serverStatus wiredTiger.cache.[\"bytes read into cache\"|\"bytes written from cache\"]",
 		[]string{"type"},
 		nil,
 	)
 	wtCacheEvictedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_cache", "evicted_total"),
-		"The total number of pages evicted from the WiredTiger Cache",
+		"source = serverStatus wiredTiger.cache.[\"modified pages evicted\"|\"unmodified pages evicted\"]",
 		[]string{"type"},
 		nil,
 	)
@@ -74,20 +74,20 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "overhead_percent",
-		Help:      "The percentage overhead of the WiredTiger Cache",
+		Help:      "source = serverStatus wiredTiger.cache.\"percentage overhead\"",
 	})
 )
 
 var (
 	wtTransactionsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_transactions", "total"),
-		"The total number of transactions WiredTiger has handled",
+		"source = serverStatus wiredTiger.transactions",
 		[]string{"type"},
 		nil,
 	)
 	wtTransactionsTotalCheckpointMsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_transactions", "checkpoint_milliseconds_total"),
-		"The total time in milliseconds transactions have checkpointed in WiredTiger",
+		"source = serverStatus wiredTiger.transactions.\"transaction checkpoint *\"",
 		nil,
 		nil,
 	)
@@ -95,38 +95,38 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_transactions",
 		Name:      "checkpoint_milliseconds",
-		Help:      "The time in milliseconds transactions have checkpointed in WiredTiger",
+		Help:      "source = serverStatus wiredTiger.transactions.\"transaction checkpoint [min|max] time (msecs)\"",
 	}, []string{"type"})
 	wtTransactionsCheckpointsRunning = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_transactions",
 		Name:      "running_checkpoints",
-		Help:      "The number of currently running checkpoints in WiredTiger",
+		Help:      "source = serverStatus wiredTiger.transactions.\"transaction checkpoint currently running\"",
 	})
 )
 
 var (
 	wtLogRecordsScannedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_log", "records_scanned_total"),
-		"The total number of records scanned by log scan in the WiredTiger log",
+		"source = serverStatus wiredTiger.log.\"records processed by log scan\"",
 		nil,
 		nil,
 	)
 	wtLogRecordsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_log", "records_total"),
-		"The total number of compressed/uncompressed records written to the WiredTiger log",
+		"source = serverStatus wiredTiger.log.[\"log records not compressed\"|\"log records compressed\"]",
 		[]string{"type"},
 		nil,
 	)
 	wtLogBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_log", "bytes_total"),
-		"The total number of bytes written to the WiredTiger log",
+		"source = serverStatus wiredTiger.log.[\"log bytes of payload data\"|\"log bytes written\"]",
 		[]string{"type"},
 		nil,
 	)
 	wtLogOperationsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "wiredtiger_log", "operations_total"),
-		"The total number of WiredTiger log operations",
+		"source = serverStatus wiredTiger.log.[\"log [flush|read|scan|sync|sync_dir|write] operations\"|\"log scan records requiring two reads\"]",
 		[]string{"type"},
 		nil,
 	)
@@ -137,13 +137,13 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_session",
 		Name:      "open_cursors_total",
-		Help:      "The total number of cursors opened in WiredTiger",
+		Help:      "source = serverStatus wiredTiger.\"open cursor count\"",
 	})
 	wtOpenSessions = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_session",
 		Name:      "open_sessions_total",
-		Help:      "The total number of sessions opened in WiredTiger",
+		Help:      "source = serverStatus wiredTiger.\"open session count\"",
 	})
 )
 
@@ -152,19 +152,19 @@ var (
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_concurrent_transactions",
 		Name:      "out_tickets",
-		Help:      "The number of tickets that are currently in use (out) in WiredTiger",
+		Help:      "source = serverStatus wiredTiger.concurrentTransactions.*.out",
 	}, []string{"type"})
 	wtConcurrentTransactionsAvailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_concurrent_transactions",
 		Name:      "available_tickets",
-		Help:      "The number of tickets that are available in WiredTiger",
+		Help:      "source = serverStatus wiredTiger.concurrentTransactions.*.available",
 	}, []string{"type"})
 	wtConcurrentTransactionsTotalTickets = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_concurrent_transactions",
 		Name:      "total_tickets",
-		Help:      "The total number of tickets that are available in WiredTiger",
+		Help:      "source = serverStatus wiredTiger.concurrentTransactions.*.totalTickets",
 	}, []string{"type"})
 )
 

--- a/collector/mongos/asserts.go
+++ b/collector/mongos/asserts.go
@@ -21,7 +21,7 @@ import (
 var (
 	assertsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "asserts_total"),
-		"The asserts document reports the number of asserts on the database. While assert errors are typically uncommon, if there are non-zero values for the asserts, you should check the log file for the mongod process for more information. In many cases these errors are trivial, but are worth investigating.",
+		"= serverStatus asserts",
 		[]string{"type"},
 		nil,
 	)

--- a/collector/mongos/collections_status.go
+++ b/collector/mongos/collections_status.go
@@ -15,37 +15,37 @@ var (
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "size",
-		Help:      "source = collStats size",
+		Help:      "= collStats size",
 	}, []string{"db", "coll"})
 	collectionObjectCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "count",
-		Help:      "source = collStats count",
+		Help:      "= collStats count",
 	}, []string{"db", "coll"})
 	collectionAvgObjSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "avgobjsize",
-		Help:      "source = collStats avgObjSize",
+		Help:      "= collStats avgObjSize",
 	}, []string{"db", "coll"})
 	collectionStorageSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "storage_size",
-		Help:      "source = collStats storageSize",
+		Help:      "= collStats storageSize",
 	}, []string{"db", "coll"})
 	collectionIndexes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "indexes",
-		Help:      "source = collStats nindexes",
+		Help:      "= collStats nindexes",
 	}, []string{"db", "coll"})
 	collectionIndexesSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "indexes_size",
-		Help:      "source = collStats totalIndexSize",
+		Help:      "= collStats totalIndexSize",
 	}, []string{"db", "coll"})
 )
 

--- a/collector/mongos/collections_status.go
+++ b/collector/mongos/collections_status.go
@@ -15,37 +15,37 @@ var (
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "size",
-		Help:      "The total size in memory of all records in a collection",
+		Help:      "source = collStats size",
 	}, []string{"db", "coll"})
 	collectionObjectCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "count",
-		Help:      "The number of objects or documents in this collection",
+		Help:      "source = collStats count",
 	}, []string{"db", "coll"})
 	collectionAvgObjSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "avgobjsize",
-		Help:      "The average size of an object in the collection (plus any padding)",
+		Help:      "source = collStats avgObjSize",
 	}, []string{"db", "coll"})
 	collectionStorageSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "storage_size",
-		Help:      "The total amount of storage allocated to this collection for document storage",
+		Help:      "source = collStats storageSize",
 	}, []string{"db", "coll"})
 	collectionIndexes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "indexes",
-		Help:      "The number of indexes on the collection",
+		Help:      "source = collStats nindexes",
 	}, []string{"db", "coll"})
 	collectionIndexesSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db_coll",
 		Name:      "indexes_size",
-		Help:      "The total size of all indexes",
+		Help:      "source = collStats totalIndexSize",
 	}, []string{"db", "coll"})
 )
 

--- a/collector/mongos/connections.go
+++ b/collector/mongos/connections.go
@@ -28,7 +28,7 @@ var (
 var (
 	connectionsMetricsCreatedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connections_metrics", "created_total"),
-		"source = serverStatsus connections.totalCreated",
+		"source = serverStatus connections.totalCreated",
 		nil,
 		nil,
 	)

--- a/collector/mongos/connections.go
+++ b/collector/mongos/connections.go
@@ -22,13 +22,13 @@ var (
 	connections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "connections",
-		Help:      "source = serverStatus connections.[current|available]",
+		Help:      "= serverStatus connections.[current|available]",
 	}, []string{"state"})
 )
 var (
 	connectionsMetricsCreatedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connections_metrics", "created_total"),
-		"source = serverStatus connections.totalCreated",
+		"= serverStatus connections.totalCreated",
 		nil,
 		nil,
 	)

--- a/collector/mongos/connections.go
+++ b/collector/mongos/connections.go
@@ -22,13 +22,13 @@ var (
 	connections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "connections",
-		Help:      "The connections sub document data regarding the current status of incoming connections and availability of the database server. Use these values to assess the current load and capacity requirements of the server",
+		Help:      "source = serverStatus connections.[current|available]",
 	}, []string{"state"})
 )
 var (
 	connectionsMetricsCreatedTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "connections_metrics", "created_total"),
-		"totalCreated provides a count of all incoming connections created to the server. This number includes connections that have since closed",
+		"source = serverStatsus connections.totalCreated",
 		nil,
 		nil,
 	)

--- a/collector/mongos/database_status.go
+++ b/collector/mongos/database_status.go
@@ -15,31 +15,31 @@ var (
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "index_size_bytes",
-		Help:      "source = dbStats indexSize",
+		Help:      "= dbStats indexSize",
 	}, []string{"db", "shard"})
 	dataSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "data_size_bytes",
-		Help:      "source = dbStats dataSize",
+		Help:      "= dbStats dataSize",
 	}, []string{"db", "shard"})
 	collectionsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "collections_total",
-		Help:      "source = dbStats collections",
+		Help:      "= dbStats collections",
 	}, []string{"db", "shard"})
 	indexesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "indexes_total",
-		Help:      "source = dbStats indexes",
+		Help:      "= dbStats indexes",
 	}, []string{"db", "shard"})
 	objectsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "objects_total",
-		Help:      "source = dbStats objects",
+		Help:      "= dbStats objects",
 	}, []string{"db", "shard"})
 )
 

--- a/collector/mongos/database_status.go
+++ b/collector/mongos/database_status.go
@@ -15,31 +15,31 @@ var (
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "index_size_bytes",
-		Help:      "The total size in bytes of all indexes created on this database",
+		Help:      "source = dbStats indexSize",
 	}, []string{"db", "shard"})
 	dataSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "data_size_bytes",
-		Help:      "The total size in bytes of the uncompressed data held in this database",
+		Help:      "source = dbStats dataSize",
 	}, []string{"db", "shard"})
 	collectionsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "collections_total",
-		Help:      "Contains a count of the number of collections in that database",
+		Help:      "source = dbStats collections",
 	}, []string{"db", "shard"})
 	indexesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "indexes_total",
-		Help:      "Contains a count of the total number of indexes across all collections in the database",
+		Help:      "source = dbStats indexes",
 	}, []string{"db", "shard"})
 	objectsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "db",
 		Name:      "objects_total",
-		Help:      "Contains a count of the number of objects (i.e. documents) in the database across all collections",
+		Help:      "source = dbStats objects",
 	}, []string{"db", "shard"})
 )
 

--- a/collector/mongos/metrics.go
+++ b/collector/mongos/metrics.go
@@ -21,7 +21,7 @@ import (
 var (
 	metricsCursorTimedOutTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_cursor", "timed_out_total"),
-		"timedOut provides the total number of cursors that have timed out since the server process started. If this number is large or growing at a regular rate, this may indicate an application error",
+		"source = serverStatus metrics.cursor.timedOut",
 		nil,
 		nil,
 	)
@@ -30,7 +30,7 @@ var (
 	metricsCursorOpen = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_cursor_open",
-		Help:      "The open is an embedded document that contains data regarding open cursors",
+		Help:      "source = serverStatus metrics.cursor.open",
 	}, []string{"state"})
 )
 var (
@@ -38,11 +38,11 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_get_last_error_wtime",
 		Name:      "num_total",
-		Help:      "num reports the total number of getLastError operations with a specified write concern (i.e. w) that wait for one or more members of a replica set to acknowledge the write operation (i.e. a w value greater than 1.)",
+		Help:      "source = serverStatus metrics.getLastError.wtimeouts",
 	})
 	metricsGetLastErrorWtimeTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_get_last_error_wtime", "total_milliseconds"),
-		"total_millis reports the total amount of time in milliseconds that the mongod has spent performing getLastError operations with write concern (i.e. w) that wait for one or more members of a replica set to acknowledge the write operation (i.e. a w value greater than 1.)",
+		"source = serverStatus metrics.getLastError.wtime.totalMillis",
 		nil,
 		nil,
 	)
@@ -50,7 +50,7 @@ var (
 var (
 	metricsGetLastErrorWtimeoutsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_get_last_error", "wtimeouts_total"),
-		"wtimeouts reports the number of times that write concern operations have timed out as a result of the wtimeout threshold to getLastError.",
+		"source = serverStatus metrics.getLastError.wtime.num",
 		nil,
 		nil,
 	)

--- a/collector/mongos/metrics.go
+++ b/collector/mongos/metrics.go
@@ -21,7 +21,7 @@ import (
 var (
 	metricsCursorTimedOutTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_cursor", "timed_out_total"),
-		"source = serverStatus metrics.cursor.timedOut",
+		"= serverStatus metrics.cursor.timedOut",
 		nil,
 		nil,
 	)
@@ -30,7 +30,7 @@ var (
 	metricsCursorOpen = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_cursor_open",
-		Help:      "source = serverStatus metrics.cursor.open",
+		Help:      "= serverStatus metrics.cursor.open",
 	}, []string{"state"})
 )
 var (
@@ -38,11 +38,11 @@ var (
 		Namespace: Namespace,
 		Subsystem: "metrics_get_last_error_wtime",
 		Name:      "num_total",
-		Help:      "source = serverStatus metrics.getLastError.wtimeouts",
+		Help:      "= serverStatus metrics.getLastError.wtimeouts",
 	})
 	metricsGetLastErrorWtimeTotalMillisecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_get_last_error_wtime", "total_milliseconds"),
-		"source = serverStatus metrics.getLastError.wtime.totalMillis",
+		"= serverStatus metrics.getLastError.wtime.totalMillis",
 		nil,
 		nil,
 	)
@@ -50,7 +50,7 @@ var (
 var (
 	metricsGetLastErrorWtimeoutsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "metrics_get_last_error", "wtimeouts_total"),
-		"source = serverStatus metrics.getLastError.wtime.num",
+		"= serverStatus metrics.getLastError.wtime.num",
 		nil,
 		nil,
 	)

--- a/collector/mongos/network.go
+++ b/collector/mongos/network.go
@@ -21,7 +21,7 @@ import (
 var (
 	networkBytesTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "network_bytes_total"),
-		"The network data structure contains data regarding MongoDB’s network use",
+		"= serverStatus network.[bytesIn|bytesOut]",
 		[]string{"state"},
 		nil,
 	)
@@ -29,7 +29,7 @@ var (
 var (
 	networkMetricsNumRequestsTotalDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "network_metrics", "num_requests_total"),
-		"The numRequests field is a counter of the total number of distinct requests that the server has received. Use this value to provide context for the bytesIn and bytesOut values to ensure that MongoDB’s network utilization is consistent with expectations and application use",
+		"= serverStatus network.numRequests",
 		nil,
 		nil,
 	)

--- a/collector/mongos/sharding_changelog.go
+++ b/collector/mongos/sharding_changelog.go
@@ -27,7 +27,7 @@ import (
 var (
 	shardingChangelogInfoDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "sharding", "changelog_10min_total"),
-		"Total # of Cluster Balancer log events over the last 10 minutes",
+		"= config.changelog (where ts within 10 min)",
 		[]string{"event"},
 		nil,
 	)

--- a/collector/mongos/sharding_status.go
+++ b/collector/mongos/sharding_status.go
@@ -33,37 +33,37 @@ var (
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "balancer_enabled",
-		Help:      "source = config.settings ({_id=\"balancer\"})",
+		Help:      "= config.settings ({_id=\"balancer\"})",
 	})
 	balancerChunksBalanced = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "chunks_is_balanced",
-		Help:      "source = config.chunks (custom algorithm simulating BalancerPolicy code)",
+		Help:      "= config.chunks (custom algorithm simulating BalancerPolicy code)",
 	})
 	mongosUpSecs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "mongos_uptime_seconds",
-		Help:      "source = conifg.mongos",
+		Help:      "= conifg.mongos",
 	}, []string{"name"})
 	mongosPing = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "mongos_last_ping_timestamp",
-		Help:      "source = conifg.mongos",
+		Help:      "= conifg.mongos",
 	}, []string{"name"})
 	mongosBalancerLockTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "balancer_lock_timestamp",
-		Help:      "source = config.locks ({_id=\"balancer\"})",
+		Help:      "= config.locks ({_id=\"balancer\"})",
 	}, []string{"name"})
 	mongosBalancerLockState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "balancer_lock_state",
-		Help:      "source = config.locks ({_id=\"balancer\"})",
+		Help:      "= config.locks ({_id=\"balancer\"})",
 	}, []string{"name"})
 )
 

--- a/collector/mongos/sharding_status.go
+++ b/collector/mongos/sharding_status.go
@@ -33,37 +33,37 @@ var (
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "balancer_enabled",
-		Help:      "Boolean reporting if cluster balancer is enabled (1 = enabled/0 = disabled)",
+		Help:      "source = config.settings ({_id=\"balancer\"})",
 	})
 	balancerChunksBalanced = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "chunks_is_balanced",
-		Help:      "Boolean reporting if cluster chunks are evenly balanced across shards (1 = yes/0 = no)",
+		Help:      "source = config.chunks (custom algorithm simulating BalancerPolicy code)",
 	})
 	mongosUpSecs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "mongos_uptime_seconds",
-		Help:      "The uptime of the Mongos processes in seconds",
+		Help:      "source = conifg.mongos",
 	}, []string{"name"})
 	mongosPing = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "mongos_last_ping_timestamp",
-		Help:      "The unix timestamp of the last Mongos ping to the Cluster config servers",
+		Help:      "source = conifg.mongos",
 	}, []string{"name"})
 	mongosBalancerLockTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "balancer_lock_timestamp",
-		Help:      "The unix timestamp of the last update to the Cluster balancer lock",
+		Help:      "source = config.locks ({_id=\"balancer\"})",
 	}, []string{"name"})
 	mongosBalancerLockState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "balancer_lock_state",
-		Help:      "The state of the Cluster balancer lock (-1 = none/0 = unlocked/1 = contention/2 = locked)",
+		Help:      "source = config.locks ({_id=\"balancer\"})",
 	}, []string{"name"})
 )
 

--- a/collector/mongos/sharding_topology.go
+++ b/collector/mongos/sharding_topology.go
@@ -31,37 +31,37 @@ var (
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "shards_total",
-		Help:      "source = config.shards",
+		Help:      "= config.shards",
 	})
 	shardingTopoInfoDrainingShards = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "shards_draining_total",
-		Help:      "source = config.shards",
+		Help:      "= config.shards",
 	})
 	shardingTopoInfoTotalChunks = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "chunks_total",
-		Help:      "source = config.chunks",
+		Help:      "= config.chunks",
 	})
 	shardingTopoInfoShardChunks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "shard_chunks_total",
-		Help:      "source = config.chunks",
+		Help:      "= config.chunks",
 	}, []string{"shard"})
 	shardingTopoInfoTotalDatabases = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "databases_total",
-		Help:      "source = config.databases",
+		Help:      "= config.databases",
 	}, []string{"type"})
 	shardingTopoInfoTotalCollections = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "collections_total",
-		Help:      "source = config.collections",
+		Help:      "= config.collections",
 	})
 )
 

--- a/collector/mongos/sharding_topology.go
+++ b/collector/mongos/sharding_topology.go
@@ -31,37 +31,37 @@ var (
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "shards_total",
-		Help:      "Total # of Shards in the Cluster",
+		Help:      "source = config.shards",
 	})
 	shardingTopoInfoDrainingShards = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "shards_draining_total",
-		Help:      "Total # of Shards in the Cluster in draining state",
+		Help:      "source = config.shards",
 	})
 	shardingTopoInfoTotalChunks = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "chunks_total",
-		Help:      "Total # of Chunks in the Cluster",
+		Help:      "source = config.chunks",
 	})
 	shardingTopoInfoShardChunks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "shard_chunks_total",
-		Help:      "Total number of chunks per shard",
+		Help:      "source = config.chunks",
 	}, []string{"shard"})
 	shardingTopoInfoTotalDatabases = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "databases_total",
-		Help:      "Total # of Databases in the Cluster",
+		Help:      "source = config.databases",
 	}, []string{"type"})
 	shardingTopoInfoTotalCollections = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "sharding",
 		Name:      "collections_total",
-		Help:      "Total # of Collections with Sharding enabled",
+		Help:      "source = config.collections",
 	})
 )
 


### PR DESCRIPTION
Rewrote the Help fields for all the metrics sourced from MongoDB. This replaces cut and paste of long descriptions from the MongoDB documentation which are not so searchable.

But mainly it will make it easier for programmers to understand which are plain counters and gauges values from MongoDB that are passed through, which are made from extra calculations (e.g. replication and operation lag), and which are info from system collections (e.g. is-balancer-enabled, number of chunks per shard, etc.)

Excluding RocksDB metrics as it has become deprecated (no storage engine except WiredTiger supported in v4.2) and it's not my area of expertise.

_(Update 2019-10-30: JIRA ticket is now PMM-4902.)_