### PR TITLE
PMM-4010 Updated travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ go:
   - 1.12.x
   # - TODO master
 
+# skip non-trunk PMM-XXXX branch builds, but still build pull requests
+branches:
+  except:
+    - /^PMM\-\d{4}/
+
+go_import_path: github.com/percona/mongodb_exporter
+
 matrix:
   allow_failures:
     - go: master


### PR DESCRIPTION
- Added go_import_path
- Made it skip non-trunk PMM-XXXX branch builds, but still build pull requests.