### PR TITLE
Add additional file system metrics

### DIFF
--- a/collector/mongod/database_status.go
+++ b/collector/mongod/database_status.go
@@ -40,6 +40,18 @@ var (
 		Name:      "objects_total",
 		Help:      "Contains a count of the number of objects (i.e. documents) in the database across all collections",
 	}, []string{"db"})
+	fsUsedSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "db",
+		Name:      "filesystem_used_bytes",
+		Help:      "Total size in bytes of all disk space in use on the filesystem where MongoDB stores data",
+	}, []string{"db"})
+	fsTotalSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "db",
+		Name:      "filesystem_size_bytes",
+		Help:      "Total size in bytes of all disk capacity on the filesystem where MongoDB stores data",
+	}, []string{"db"})
 )
 
 // DatabaseStatList contains stats from all databases
@@ -55,6 +67,8 @@ type DatabaseStatus struct {
 	Collections int    `bson:"collections,omitempty"`
 	Objects     int    `bson:"objects,omitempty"`
 	Indexes     int    `bson:"indexes,omitempty"`
+	FsUsedSize  int    `bson:"fsUsedSize"`
+	FsTotalSize int    `bson:"fsTotalSize"`
 }
 
 // Export exports database stats to prometheus
@@ -66,12 +80,16 @@ func (dbStatList *DatabaseStatList) Export(ch chan<- prometheus.Metric) {
 		collectionsTotal.With(ls).Set(float64(member.Collections))
 		indexesTotal.With(ls).Set(float64(member.Indexes))
 		objectsTotal.With(ls).Set(float64(member.Objects))
+		fsUsedSize.With(ls).Set(float64(member.FsUsedSize))
+		fsTotalSize.With(ls).Set(float64(member.FsTotalSize))
 	}
 	indexSize.Collect(ch)
 	dataSize.Collect(ch)
 	collectionsTotal.Collect(ch)
 	indexesTotal.Collect(ch)
 	objectsTotal.Collect(ch)
+	fsUsedSize.Collect(ch)
+	fsTotalSize.Collect(ch)
 
 }
 
@@ -82,6 +100,8 @@ func (dbStatList *DatabaseStatList) Describe(ch chan<- *prometheus.Desc) {
 	collectionsTotal.Describe(ch)
 	indexesTotal.Describe(ch)
 	objectsTotal.Describe(ch)
+	fsUsedSize.Describe(ch)
+	fsTotalSize.Describe(ch)
 }
 
 // GetDatabaseStatList returns stats for all databases


### PR DESCRIPTION
We like to also monitor the filesystem size and free bytes on managed MongoDB instances where we can't access metrics from the host system itself.