### PR TITLE
Makefile support for colon-delimited GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 GO          := go
-GOPATH      := $(shell $(GO) env GOPATH)
+GOPATH      := $(shell $(GO) env GOPATH | cut -d: -f1)
 pkgs		= ./...
 
 PREFIX              ?= $(shell pwd)


### PR DESCRIPTION
Having multiple paths in GOPATH is valid, and a strategy some developers use to separate concerns (default, work, and personal). Where multiple entries exist in gopath, "go get" will install binaries into the first listed path.