### PR TITLE
Workaround for GODRIVER-1476

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Those flags have been removed: `--mongodb.authentification-database, --mongodb.m
 ### Added
 
 ### Fixed
+- Added a workaround for [GODRIVER-1476](https://jira.mongodb.org/browse/GODRIVER-1476) (mongodb+srv URIs with fully qualified DNS names)
 
 ## [0.10.0]
 ### Changed


### PR DESCRIPTION
There's a PR upstream for mongo-go-driver, but until it's approved and merged/backported, I'm submitting this workaround for consideration.

Details on the bug are over in [GODRIVER-1476](https://jira.mongodb.org/browse/GODRIVER-1476)