### PR TITLE
Collection improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [PMM-4719](https://jira.percona.com/browse/PMM-4719): Remove redundant flags from "mongodb_exporter" if possible. 
 Those flags have been removed: `--mongodb.authentification-database, --mongodb.max-connections, --mongodb.socket-timeout, --mongodb.sync-timeout`. You can use [connection-string-options](https://docs.mongodb.com/manual/reference/connection-string/#connection-string-options) instead.
+- Add `--collect.exclude-system` to exclude `system.*` collections from Index and Collection stats.
 
 ### Added
 

--- a/collector/mongod/index_usage.go
+++ b/collector/mongod/index_usage.go
@@ -2,6 +2,7 @@ package mongod
 
 import (
 	"context"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
@@ -60,7 +61,7 @@ var (
 )
 
 // GetIndexUsageStatList returns stats for a given collection in a database
-func GetIndexUsageStatList(client *mongo.Client) *IndexStatsList {
+func GetIndexUsageStatList(client *mongo.Client, excludeSystemCollections bool) *IndexStatsList {
 	indexUsageStatsList := &IndexStatsList{}
 	databaseNames, err := client.ListDatabaseNames(context.TODO(), bson.M{})
 	if err != nil {
@@ -93,6 +94,10 @@ func GetIndexUsageStatList(client *mongo.Client) *IndexStatsList {
 				err := c.Decode(&coll)
 				if err != nil {
 					log.Error(err)
+					continue
+				}
+
+				if excludeSystemCollections && strings.HasPrefix(coll.Name, "system.") {
 					continue
 				}
 

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -37,6 +37,7 @@ type MongodbCollectorOpts struct {
 	URI                      string
 	CollectDatabaseMetrics   bool
 	CollectCollectionMetrics bool
+	ExcludeSystemCollections bool
 	CollectTopMetrics        bool
 	CollectIndexUsageStats   bool
 	CollectConnPoolStats     bool
@@ -242,7 +243,7 @@ func (exporter *MongodbCollector) collectMongos(client *mongo.Client, ch chan<- 
 
 	if exporter.Opts.CollectCollectionMetrics {
 		log.Debug("Collecting Collection Status From Mongos")
-		collStatList := mongos.GetCollectionStatList(client)
+		collStatList := mongos.GetCollectionStatList(client, exporter.Opts.ExcludeSystemCollections)
 		if collStatList != nil {
 			collStatList.Export(ch)
 		}
@@ -274,7 +275,7 @@ func (exporter *MongodbCollector) collectMongod(client *mongo.Client, ch chan<- 
 
 	if exporter.Opts.CollectCollectionMetrics {
 		log.Debug("Collecting Collection Status From Mongod")
-		collStatList := mongod.GetCollectionStatList(client)
+		collStatList := mongod.GetCollectionStatList(client, exporter.Opts.ExcludeSystemCollections)
 		if collStatList != nil {
 			collStatList.Export(ch)
 		}
@@ -290,7 +291,7 @@ func (exporter *MongodbCollector) collectMongod(client *mongo.Client, ch chan<- 
 
 	if exporter.Opts.CollectIndexUsageStats {
 		log.Debug("Collecting Index Statistics")
-		indexStatList := mongod.GetIndexUsageStatList(client)
+		indexStatList := mongod.GetIndexUsageStatList(client, exporter.Opts.ExcludeSystemCollections)
 		if indexStatList != nil {
 			indexStatList.Export(ch)
 		}

--- a/collector/mongos/collections_status.go
+++ b/collector/mongos/collections_status.go
@@ -48,6 +48,12 @@ var (
 		Name:      "indexes_size",
 		Help:      "The total size of all indexes",
 	}, []string{"db", "coll"})
+	collectionIndexSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "db_coll",
+		Name:      "index_size",
+		Help:      "The individual index size",
+	}, []string{"db", "coll", "index"})
 )
 
 // CollectionStatList contains stats from all collections
@@ -59,12 +65,12 @@ type CollectionStatList struct {
 type CollectionStatus struct {
 	Database    string
 	Name        string
-	Size        int `bson:"size,omitempty"`
-	Count       int `bson:"count,omitempty"`
-	AvgObjSize  int `bson:"avgObjSize,omitempty"`
-	StorageSize int `bson:"storageSize,omitempty"`
-	Indexes     int `bson:"indexSizes,omitempty"`
-	IndexesSize int `bson:"totalIndexSize,omitempty"`
+	Size        int                `bson:"size,omitempty"`
+	Count       int                `bson:"count,omitempty"`
+	AvgObjSize  int                `bson:"avgObjSize,omitempty"`
+	StorageSize int                `bson:"storageSize,omitempty"`
+	IndexesSize int                `bson:"totalIndexSize,omitempty"`
+	IndexSizes  map[string]float64 `bson:"indexSizes,omitempty"`
 }
 
 // Export exports database stats to prometheus
@@ -78,8 +84,16 @@ func (collStatList *CollectionStatList) Export(ch chan<- prometheus.Metric) {
 		collectionObjectCount.With(ls).Set(float64(member.Count))
 		collectionAvgObjSize.With(ls).Set(float64(member.AvgObjSize))
 		collectionStorageSize.With(ls).Set(float64(member.StorageSize))
-		collectionIndexes.With(ls).Set(float64(member.Indexes))
+		collectionIndexes.With(ls).Set(float64(len(member.IndexSizes)))
 		collectionIndexesSize.With(ls).Set(float64(member.IndexesSize))
+		for indexName, size := range member.IndexSizes {
+			ls = prometheus.Labels{
+				"db":    member.Database,
+				"coll":  member.Name,
+				"index": indexName,
+			}
+			collectionIndexSize.With(ls).Set(size)
+		}
 	}
 	collectionSize.Collect(ch)
 	collectionObjectCount.Collect(ch)
@@ -87,6 +101,7 @@ func (collStatList *CollectionStatList) Export(ch chan<- prometheus.Metric) {
 	collectionStorageSize.Collect(ch)
 	collectionIndexes.Collect(ch)
 	collectionIndexesSize.Collect(ch)
+	collectionIndexSize.Collect(ch)
 }
 
 // Describe describes database stats for prometheus

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -44,6 +44,7 @@ var (
 
 	collectDatabaseF             = kingpin.Flag("collect.database", "Enable collection of Database metrics").Bool()
 	collectCollectionF           = kingpin.Flag("collect.collection", "Enable collection of Collection metrics").Bool()
+	excludeSystemCollectionsF    = kingpin.Flag("collect.exclude-system", "Exclude collection of system.* Collection metrics").Bool()
 	collectTopF                  = kingpin.Flag("collect.topmetrics", "Enable collection of table top metrics").Bool()
 	collectIndexUsageF           = kingpin.Flag("collect.indexusage", "Enable collection of per index usage stats").Bool()
 	mongodbCollectConnPoolStatsF = kingpin.Flag("collect.connpoolstats", "Collect MongoDB connpoolstats").Bool()
@@ -85,6 +86,7 @@ func main() {
 		URI:                      *uriF,
 		CollectDatabaseMetrics:   *collectDatabaseF,
 		CollectCollectionMetrics: *collectCollectionF,
+		ExcludeSystemCollections: *excludeSystemCollectionsF,
 		CollectTopMetrics:        *collectTopF,
 		CollectIndexUsageStats:   *collectIndexUsageF,
 		CollectConnPoolStats:     *mongodbCollectConnPoolStatsF,

--- a/testdata/mongodb_exporter.testFlagHelp.golden
+++ b/testdata/mongodb_exporter.testFlagHelp.golden
@@ -3,37 +3,39 @@ usage: mongodb_exporter [<flags>]
 exports various MongoDB metrics in Prometheus format.
 
 Flags:
-  -h, --help                   Show context-sensitive help (also try --help-long
-                               and --help-man).
+  -h, --help                    Show context-sensitive help (also try
+                                --help-long and --help-man).
       --web.auth-file=WEB.AUTH-FILE  
-                               Path to YAML file with server_user,
-                               server_password keys for HTTP Basic
-                               authentication (overrides HTTP_AUTH environment
-                               variable).
+                                Path to YAML file with server_user,
+                                server_password keys for HTTP Basic
+                                authentication (overrides HTTP_AUTH environment
+                                variable).
       --web.ssl-cert-file=WEB.SSL-CERT-FILE  
-                               Path to SSL certificate file.
+                                Path to SSL certificate file.
       --web.ssl-key-file=WEB.SSL-KEY-FILE  
-                               Path to SSL key file.
+                                Path to SSL key file.
       --web.listen-address=":9216"  
-                               Address to listen on for web interface and
-                               telemetry.
+                                Address to listen on for web interface and
+                                telemetry.
       --web.telemetry-path="/metrics"  
-                               Path under which to expose metrics.
-      --collect.database       Enable collection of Database metrics
-      --collect.collection     Enable collection of Collection metrics
-      --collect.topmetrics     Enable collection of table top metrics
-      --collect.indexusage     Enable collection of per index usage stats
-      --collect.connpoolstats  Collect MongoDB connpoolstats
+                                Path under which to expose metrics.
+      --collect.database        Enable collection of Database metrics
+      --collect.collection      Enable collection of Collection metrics
+      --collect.exclude-system  Exclude collection of system.* Collection
+                                metrics
+      --collect.topmetrics      Enable collection of table top metrics
+      --collect.indexusage      Enable collection of per index usage stats
+      --collect.connpoolstats   Collect MongoDB connpoolstats
       --mongodb.uri=[mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]  
-                               MongoDB URI, format
-      --test                   Check MongoDB connection, print buildInfo()
-                               information and exit.
-      --version                Show application version.
-      --log.level="info"       Only log messages with the given severity or
-                               above. Valid levels: [debug, info, warn, error,
-                               fatal]
+                                MongoDB URI, format
+      --test                    Check MongoDB connection, print buildInfo()
+                                information and exit.
+      --version                 Show application version.
+      --log.level="info"        Only log messages with the given severity or
+                                above. Valid levels: [debug, info, warn, error,
+                                fatal]
       --log.format="logger:stderr"  
-                               Set the log target and format. Example:
-                               "logger:syslog?appname=bob&local=7" or
-                               "logger:stdout?json=true"
+                                Set the log target and format. Example:
+                                "logger:syslog?appname=bob&local=7" or
+                                "logger:stdout?json=true"
 


### PR DESCRIPTION
* Add an option to exclude system.* collections from index/coll stats
    
    On auth-enabled deployments, the clusterMonitor role doesn't grant
    collStats or listIndexes on all system.* collections, so it's probably
    best to have a way to disable it to prevent spurious warnings.

* Fix collStats collection via mongos
    
    Copied the base code from mongod collStats for now, and verified it
    works against an mlaunch cluster on 3.6