### PR TITLE
Chunks per shard per collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,8 @@ clean:
 	@echo ">> removing build artifacts"
 	@rm -f $(PREFIX)/coverage.txt
 	@rm -Rf $(PREFIX)/bin
-	docker-compose down
+	@echo ">> downing docker test environment if docker-compose is available"
+	@if docker-compose --version 2>/dev/null >/dev/null ; then docker-compose down ; fi
 
 mongo-db-in-docker:
 	# Start docker containers.

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -40,6 +40,7 @@ type MongodbCollectorOpts struct {
 	CollectTopMetrics        bool
 	CollectIndexUsageStats   bool
 	CollectConnPoolStats     bool
+	CollectChunkMetrics      bool
 }
 
 func (in *MongodbCollectorOpts) toSessionOps() *shared.MongoSessionOpts {
@@ -253,6 +254,14 @@ func (exporter *MongodbCollector) collectMongos(client *mongo.Client, ch chan<- 
 		connPoolStats := commoncollector.GetConnPoolStats(client)
 		if connPoolStats != nil {
 			connPoolStats.Export(ch)
+		}
+	}
+
+	if exporter.Opts.CollectChunkMetrics {
+		log.Debug("Collecting Chunk Counts From Mongos")
+		chunkCountList := mongos.GetChunkCountList(client)
+		if chunkCountList != nil {
+			chunkCountList.Export(ch)
 		}
 	}
 }

--- a/collector/mongos/server_status_test.go
+++ b/collector/mongos/server_status_test.go
@@ -95,3 +95,18 @@ func TestGetServerStatusDecodesFine(t *testing.T) {
 	// test
 	assert.NotNil(t, statusDefault)
 }
+
+func TestGetShardChunksDecodesFine(t *testing.T) {
+	// setup
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	client := testutils.MustGetConnectedReplSetClient(ctx, t)
+	defer client.Disconnect(ctx)
+
+	// run
+	status := GetShardChunks(client)
+
+	// test
+	assert.NotNil(t, status)
+}
+

--- a/collector/mongos/sharding_chunks.go
+++ b/collector/mongos/sharding_chunks.go
@@ -1,0 +1,97 @@
+
+package mongos
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+)
+
+var (
+	mongosShardChunks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "sharding",
+		Name:      "namespace_shard_chunks",
+		Help:      "The count of chunks per shard per collection",
+	}, []string{"namespace","shard"})
+)
+
+type AggegateId struct {
+	Namespace string `bson:"ns"`
+	Shard     string `bson:"shard"`
+}
+
+type AggregateOut struct {
+	Inner AggegateId `bson:"_id"`
+	Count int64      `bson:"count"`
+}
+
+type ChunksInfo struct {
+	Namespace string
+	Shard     string
+	Chunks    int64
+}
+
+type ShardingCounts struct {
+	ShardChunks     *[]ChunksInfo
+}
+
+// GetShardChunks counts up chunks per collection per shard
+func GetShardChunks(client *mongo.Client) *[]ChunksInfo {
+	chunksInfo := []ChunksInfo{}
+
+	matching := bson.M{}
+	grouping := bson.M{"_id": bson.M{
+		"ns":    "$ns",
+		"shard": "$shard",
+	},
+		"count": bson.M{"$sum": 1},
+	}
+
+	c, err := client.Database("config").Collection("chunks").Aggregate(context.TODO(), []bson.M{{"$match": matching}, {"$group": grouping}})
+	if err != nil {
+		log.Errorf("Failed to execute aggregate on 'config.chunks': %s.", err)
+		return nil
+	}
+	defer c.Close(context.TODO())
+
+	for c.Next(context.TODO()) {
+		i := &ChunksInfo{}
+		a := &AggregateOut{}
+		if err := c.Decode(a); err != nil {
+			log.Error(err)
+			continue
+		}
+		i.Namespace = a.Inner.Namespace
+		i.Shard = a.Inner.Shard
+		i.Chunks = a.Count
+		chunksInfo = append(chunksInfo, *i)
+	}
+
+	return &chunksInfo
+}
+
+func (status *ShardingCounts) Export(ch chan<- prometheus.Metric) {
+	if status.ShardChunks != nil {
+		for _, chunkInfo := range *status.ShardChunks {
+			// ...WithLabelValues().Set() only accepts float64 even though an
+			// integer type is a better fit
+			mongosShardChunks.WithLabelValues(chunkInfo.Namespace,chunkInfo.Shard).Set(float64(chunkInfo.Chunks))
+		}
+	}
+	mongosShardChunks.Collect(ch)
+}
+
+func (status *ShardingCounts) Describe(ch chan<- *prometheus.Desc) {
+	mongosShardChunks.Describe(ch)
+}
+
+func GetChunkCountList(client *mongo.Client) *ShardingCounts {
+	results := &ShardingCounts{}
+	results.ShardChunks = GetShardChunks(client)
+	return results
+}

--- a/collector/mongos/sharding_status.go
+++ b/collector/mongos/sharding_status.go
@@ -208,6 +208,7 @@ func (status *ShardingStats) Export(ch chan<- prometheus.Metric) {
 	mongosPing.Collect(ch)
 	mongosBalancerLockState.Collect(ch)
 	mongosBalancerLockTimestamp.Collect(ch)
+
 }
 
 func (status *ShardingStats) Describe(ch chan<- *prometheus.Desc) {

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -47,6 +47,7 @@ var (
 	collectTopF                  = kingpin.Flag("collect.topmetrics", "Enable collection of table top metrics").Bool()
 	collectIndexUsageF           = kingpin.Flag("collect.indexusage", "Enable collection of per index usage stats").Bool()
 	mongodbCollectConnPoolStatsF = kingpin.Flag("collect.connpoolstats", "Collect MongoDB connpoolstats").Bool()
+	collectChunksF               = kingpin.Flag("collect.chunkstats", "Enable counting of chunks per shard per collection (slow when counts are high)").Bool()
 
 	uriF = kingpin.Flag("mongodb.uri", "MongoDB URI, format").
 		PlaceHolder("[mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]").
@@ -88,6 +89,7 @@ func main() {
 		CollectTopMetrics:        *collectTopF,
 		CollectIndexUsageStats:   *collectIndexUsageF,
 		CollectConnPoolStats:     *mongodbCollectConnPoolStatsF,
+		CollectChunkMetrics:      *collectChunksF,
 	})
 	prometheus.MustRegister(programCollector, mongodbCollector)
 

--- a/testdata/mongodb_exporter.testFlagHelp.golden
+++ b/testdata/mongodb_exporter.testFlagHelp.golden
@@ -24,6 +24,8 @@ Flags:
       --collect.topmetrics     Enable collection of table top metrics
       --collect.indexusage     Enable collection of per index usage stats
       --collect.connpoolstats  Collect MongoDB connpoolstats
+      --collect.chunkstats     Enable counting of chunks per shard per
+                               collection (slow when counts are high)
       --mongodb.uri=[mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]  
                                MongoDB URI, format
       --test                   Check MongoDB connection, print buildInfo()


### PR DESCRIPTION
This adds a new file to collect chunks per database per shard and export it, gated by a command line option: `--collect.chunkstats` . The collection is not done by default as when there are a large number of chunks this can be a slow metric to collect.

The exported data looks like:
```
# HELP mongodb_mongos_sharding_namespace_shard_chunks The count of chunks per shard per collection
# TYPE mongodb_mongos_sharding_namespace_shard_chunks gauge
mongodb_mongos_sharding_namespace_shard_chunks{namespace="agent.bothways",shard="rs1"} 78
mongodb_mongos_sharding_namespace_shard_chunks{namespace="agent.bothways",shard="rs2"} 79
mongodb_mongos_sharding_namespace_shard_chunks{namespace="agent.ping",shard="rs1"} 1458
mongodb_mongos_sharding_namespace_shard_chunks{namespace="agent.ping",shard="rs2"} 1458
mongodb_mongos_sharding_namespace_shard_chunks{namespace="devicemanager.deviceInterfaces",shard="rs1"} 1350
mongodb_mongos_sharding_namespace_shard_chunks{namespace="devicemanager.deviceInterfaces",shard="rs2"} 1349
```