### PR TITLE
Print log message when failed to create a client

### DIFF
--- a/shared/connection.go
+++ b/shared/connection.go
@@ -65,6 +65,7 @@ func MongoClient(opts *MongoSessionOpts) *mongo.Client {
 
 	client, err := mongo.NewClient(cOpts)
 	if err != nil {
+		log.Errorf("Cannot create client %s: %s", RedactMongoUri(opts.URI), err)
 		return nil
 	}
 


### PR DESCRIPTION
Otherwise it's hard to debug problems with invalid connection string