### PR TITLE
PMM-6113 fix replSetGetConfig parse error

### DIFF
--- a/collector/mongod/replset_conf.go
+++ b/collector/mongod/replset_conf.go
@@ -60,12 +60,12 @@ type ReplSetConf struct {
 
 // MemberConf represents an array element of ReplSetConf.Members
 type MemberConf struct {
-	ID           int32  `bson:"_id"`
-	Host         string `bson:"host"`
-	ArbiterOnly  bool   `bson:"arbiterOnly"`
-	BuildIndexes bool   `bson:"buildIndexes"`
-	Hidden       bool   `bson:"hidden"`
-	Priority     int32  `bson:"priority"`
+	ID           int32   `bson:"_id"`
+	Host         string  `bson:"host"`
+	ArbiterOnly  bool    `bson:"arbiterOnly"`
+	BuildIndexes bool    `bson:"buildIndexes"`
+	Hidden       bool    `bson:"hidden"`
+	Priority     float64 `bson:"priority"`
 
 	Tags       map[string]string `bson:"tags"`
 	SlaveDelay float64           `bson:"saveDelay"`
@@ -93,7 +93,7 @@ func (replConf *ReplSetConf) Export(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(memberBuildIndexesDesc, prometheus.GaugeValue, 0, replConf.ID, member.Host)
 		}
 
-		ch <- prometheus.MustNewConstMetric(memberPriorityDesc, prometheus.GaugeValue, float64(member.Priority), replConf.ID, member.Host)
+		ch <- prometheus.MustNewConstMetric(memberPriorityDesc, prometheus.GaugeValue, member.Priority, replConf.ID, member.Host)
 		ch <- prometheus.MustNewConstMetric(memberVotesDesc, prometheus.GaugeValue, float64(member.Votes), replConf.ID, member.Host)
 	}
 }


### PR DESCRIPTION
Faced with similar problem described in [PMM-6113](https://jira.percona.com/browse/PMM-6113)
I applied part of patch offered by author of the ticket and it helped me to fix error `Failed to get replSetGetConfig: IntDecodeValue can only truncate float64 to an integer type when truncation is enabled`.

