### PR TITLE
Add directory into releases archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
         - -s -w -X main.commit={{.ShortCommit}} -X main.buildDate={{.Date}}
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Version }}.{{ .Os }}-{{ .Arch }}"
+    wrap_in_directory: true
 snapshot:
   name_template: "{{ .ShortCommit }}"
 changelog:


### PR DESCRIPTION
In order to align release tarbals with other community prom exporter releases it may be good to have the folder inside tar.gz archive like for example here:
https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-amd64.tar.gz
We need this to deploy all exporters with single Ansible role https://github.com/entercloudsuite/ansible-prometheus-exporter
Current archive dirrectory structure breaks this flow.