### PR TITLE
Adding auto assign review team

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,11 @@
+[PMM-XXXX](https://jira.percona.com/browse/PMM-XXXX) (optional, if ticket reported)
+
+- [ ] Links to other linked pull requests (optional).
+---
+- [ ] Tests passed.
+- [ ] Fix conflicts with target branch.
+- [ ] Update jira ticket description if needed.
+- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.
 
 
-When all checks have passed and code is ready for the review, please add `pmm-review-exporters` as the reviewer. That would assign people from the review team automatically.
+When all checks have passed and code is ready for the review, bot should add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forums](https://forums.percona.com) and [Discord](https://discord.gg/mQEyGPkNbR).

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -11,5 +11,5 @@ jobs:
       uses: percona-platform/auto-assign-review-teams@p1.0.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        teams: "pmm-review-exporters"
+        teams: "@percona/pmm-review-exporters"
         skip-with-manual-reviewers: 2

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -1,7 +1,7 @@
 name: "Assign Reviewers"
 on:  
   pull_request:
-    types: [opened, ready_for_review]
+    types: [ready_for_review]
      
 jobs:
   assign-reviewers:

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -1,0 +1,15 @@
+name: "Assign Reviewers"
+on:  
+  pull_request:
+    types: [opened, ready_for_review]
+     
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Assign Team for the review"
+      uses: percona-platform/auto-assign-review-teams@v1.0.1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        teams: "pmm-review-exporters"
+        skip-with-manual-reviewers: 2

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Assign Team for the review"
-      uses: percona-platform/auto-assign-review-teams@v1.0.1
+      uses: percona-platform/auto-assign-review-teams@p1.0.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         teams: "pmm-review-exporters"

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Assign Team for the review"
-      uses: percona-platform/auto-assign-review-teams@p1.0.1
+      uses: percona-platform/auto-assign-review-teams@v1.0.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        teams: "@percona/pmm-review-exporters"
+        teams: "teams:@percona/pmm-review-exporters"
         skip-with-manual-reviewers: 2

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Assign Team for the review"
-      uses: percona-platform/auto-assign-review-teams@v1.0.1
+      uses: percona-platform/auto-assign-review-teams@v.1.0.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        teams: "teams:@percona/pmm-review-exporters"
+        teams: "pmm-review-exporters"
         skip-with-manual-reviewers: 2


### PR DESCRIPTION
Add gh action that would assign review team for the PR that are ready.
Clean PR template.



When all checks have passed and code is ready for the review, please add `pmm-review-exporters` as the reviewer. That would assign people from the review team automatically.