### PR TITLE
More labels for replSetGetStatus() info

### DIFF
--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -293,10 +293,10 @@ func makeMetrics(prefix string, m bson.M, labels map[string]string, compatibleMo
 
 // Extract maps from arrays. Only some structures like replicasets have arrays of members
 // and each member is represented by a map[string]interface{}.
-func processSlice(prefix, k string, v []interface{}, common_labels map[string]string, compatibleMode bool) []prometheus.Metric {
+func processSlice(prefix, k string, v []interface{}, commonLabels map[string]string, compatibleMode bool) []prometheus.Metric {
 	metrics := make([]prometheus.Metric, 0)
 	labels := make(map[string]string)
-	for name, value := range common_labels {
+	for name, value := range commonLabels {
 		labels[name] = value
 	}
 
@@ -315,6 +315,9 @@ func processSlice(prefix, k string, v []interface{}, common_labels map[string]st
 		// use the replicaset or server name as a label
 		if name, ok := s["name"].(string); ok {
 			labels["member_idx"] = name
+		}
+		if state, ok := s["stateStr"].(string); ok {
+			labels["member_state"] = state
 		}
 
 		metrics = append(metrics, makeMetrics(prefix+k, s, labels, compatibleMode)...)

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -248,7 +248,7 @@ func makeMetrics(prefix string, m bson.M, labels map[string]string, compatibleMo
 			res = append(res, makeMetrics(prefix+k, v, labels, compatibleMode)...)
 		case primitive.A:
 			v = []interface{}(v)
-			res = append(res, processSlice(prefix, k, v, compatibleMode)...)
+			res = append(res, processSlice(prefix, k, v, labels, compatibleMode)...)
 		case []interface{}:
 			continue
 		default:
@@ -293,9 +293,12 @@ func makeMetrics(prefix string, m bson.M, labels map[string]string, compatibleMo
 
 // Extract maps from arrays. Only some structures like replicasets have arrays of members
 // and each member is represented by a map[string]interface{}.
-func processSlice(prefix, k string, v []interface{}, compatibleMode bool) []prometheus.Metric {
+func processSlice(prefix, k string, v []interface{}, common_labels map[string]string, compatibleMode bool) []prometheus.Metric {
 	metrics := make([]prometheus.Metric, 0)
 	labels := make(map[string]string)
+	for name, value := range common_labels {
+		labels[name] = value
+	}
 
 	for _, item := range v {
 		var s map[string]interface{}


### PR DESCRIPTION
Add common labels to members info parsed from `replSetGetStatus()`. Also, add `member_state` as a label if exists. Without these changes, members metrics almost useless because we have only `member_idx` label. So, for example, calculate replication lag as the difference between `optimeDate` fields isn't possible because we don't know who is primary and to which cluster this member belongs to.