### PR TITLE
PMM-6864 missing old metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .dist
 .env
 .vscode/
+.idea
 bin
 build
 dist

--- a/exporter/secondary_lag_test.go
+++ b/exporter/secondary_lag_test.go
@@ -118,6 +118,7 @@ func TestSecondaryLag(t *testing.T) {
 	for _, m := range metrics {
 		if strings.HasPrefix(m.Desc().String(), `Desc{fqName: "mongodb_mongod_replset_member_replication_lag"`) {
 			lag = m
+
 			break
 		}
 	}

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -858,7 +858,7 @@ func oplogStatus(ctx context.Context, client *mongo.Client) ([]prometheus.Metric
 
 }
 
-// replSetStatus keeps the data returned by the GetReplSetStatus method
+// replSetStatus keeps the data returned by the GetReplSetStatus command.
 type replSetStatus struct {
 	Set                     string    `bson:"set"`
 	Date                    time.Time `bson:"date"`
@@ -868,7 +868,7 @@ type replSetStatus struct {
 	Members                 []member  `bson:"members"`
 }
 
-// member represents an array element of ReplSetStatus.Members
+// member represents an array element of replSetStatus.Members.
 type member struct {
 	ID                   int         `bson:"_id"`
 	Name                 string      `bson:"name"`
@@ -912,6 +912,7 @@ func replSetMetrics(m bson.M) []prometheus.Metric {
 		if m.StateStr == "PRIMARY" {
 			primaryOpTime = m.OptimeDate
 			gotPrimary = true
+
 			break
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/AlekSi/pointer v1.1.0
 	github.com/alecthomas/kong v0.2.16
 	github.com/percona/exporter_shared v0.7.2
-	github.com/percona/percona-toolkit v0.0.0-20210317160132-05526474504f
+	github.com/percona/percona-toolkit v0.0.0-20210504134948-4dd72d96b10d
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -302,8 +302,8 @@ github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUr
 github.com/percona/exporter_shared v0.7.2 h1:8eNBht83bgFagdiIm3b4HbsOFc5du6OUBCUVenTumdw=
 github.com/percona/exporter_shared v0.7.2/go.mod h1:AWk9lgTPzI7tC5PzpeBGvhhqjSJNxpPNFaF7qLIJqmo=
 github.com/percona/go-mysql v0.0.0-20190903141930-197f4ad8db8d/go.mod h1:/SGLf9OMxlnK6jq4mkFiImBcJXXk5jwD+lDrwDaGXcw=
-github.com/percona/percona-toolkit v0.0.0-20210317160132-05526474504f h1:V2zOPuZn4XFEojOV7DrJD5feZwi6gT0SodAmZ2s7CIU=
-github.com/percona/percona-toolkit v0.0.0-20210317160132-05526474504f/go.mod h1:uGrhLglXccEIplDyzQSJfv3UWG5J7ACFjaZebntKStQ=
+github.com/percona/percona-toolkit v0.0.0-20210504134948-4dd72d96b10d h1:RCnD2c2+ur6z0Lee/VLEXuGT1TKvZs/i3nYrWZ4WrT0=
+github.com/percona/percona-toolkit v0.0.0-20210504134948-4dd72d96b10d/go.mod h1:uGrhLglXccEIplDyzQSJfv3UWG5J7ACFjaZebntKStQ=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=


### PR DESCRIPTION
[PMM-6864](https://jira.percona.com/browse/PMM-6864)
I tried to fill every metric needed for https://pmmdemo.percona.com/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?orgId=1&refresh=1m

But this one is still missing: `mongodb_tcmalloc_cache_bytes`

- [ ] Links to other linked pull requests (optional).
---
FB: https://github.com/Percona-Lab/pmm-submodules/pull/1720
- [ ] Tests passed.
- [ ] Fix conflicts with target branch.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.


When all checks have passed and code is ready for the review, bot should add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forums](https://forums.percona.com) and [Discord](https://discord.gg/mQEyGPkNbR).
