### PR TITLE
Add storage stats to collection metrics

### DIFF
--- a/exporter/collstats_collector.go
+++ b/exporter/collstats_collector.go
@@ -63,13 +63,23 @@ func (d *collstatsCollector) Collect(ch chan<- prometheus.Metric) {
 		collection := parts[1]
 
 		aggregation := bson.D{
-			{Key: "$collStats", Value: bson.M{
-				"latencyStats": bson.E{Key: "histograms", Value: true},
-				"storageStats": bson.E{Key: "scale", Value: 1},
-			}},
+			{
+				Key: "$collStats", Value: bson.M{
+					"latencyStats": bson.E{Key: "histograms", Value: true},
+					"storageStats": bson.E{Key: "scale", Value: 1},
+				},
+			},
+		}
+		project := bson.D{
+			{
+				Key: "$project", Value: bson.M{
+					"storageStats.wiredTiger":   0,
+					"storageStats.indexDetails": 0,
+				},
+			},
 		}
 
-		cursor, err := d.client.Database(database).Collection(collection).Aggregate(d.ctx, mongo.Pipeline{aggregation})
+		cursor, err := d.client.Database(database).Collection(collection).Aggregate(d.ctx, mongo.Pipeline{aggregation, project})
 		if err != nil {
 			d.logger.Errorf("cannot get $collstats cursor for collection %s.%s: %s", database, collection, err)
 			continue

--- a/exporter/collstats_collector.go
+++ b/exporter/collstats_collector.go
@@ -63,7 +63,10 @@ func (d *collstatsCollector) Collect(ch chan<- prometheus.Metric) {
 		collection := parts[1]
 
 		aggregation := bson.D{
-			{Key: "$collStats", Value: bson.M{"latencyStats": bson.E{Key: "histograms", Value: true}}},
+			{Key: "$collStats", Value: bson.M{
+				"latencyStats": bson.E{Key: "histograms", Value: true},
+				"storageStats": bson.E{Key: "scale", Value: 1},
+			}},
 		}
 
 		cursor, err := d.client.Database(database).Collection(collection).Aggregate(d.ctx, mongo.Pipeline{aggregation})

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/AlekSi/pointer v1.1.0
 	github.com/alecthomas/kong v0.2.16
 	github.com/percona/exporter_shared v0.7.2
-	github.com/percona/percona-toolkit v0.0.0-20210504134948-4dd72d96b10d
+	github.com/percona/percona-toolkit v0.0.0-20210422154412-6917c5dd8594
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/AlekSi/pointer v1.1.0
 	github.com/alecthomas/kong v0.2.16
 	github.com/percona/exporter_shared v0.7.2
-	github.com/percona/percona-toolkit v0.0.0-20210422154412-6917c5dd8594
+	github.com/percona/percona-toolkit v0.0.0-20210503082911-610ab8c66a81
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/percona/exporter_shared v0.7.2 h1:8eNBht83bgFagdiIm3b4HbsOFc5du6OUBCUVenTumdw=
 github.com/percona/exporter_shared v0.7.2/go.mod h1:AWk9lgTPzI7tC5PzpeBGvhhqjSJNxpPNFaF7qLIJqmo=
 github.com/percona/go-mysql v0.0.0-20190903141930-197f4ad8db8d/go.mod h1:/SGLf9OMxlnK6jq4mkFiImBcJXXk5jwD+lDrwDaGXcw=
-github.com/percona/percona-toolkit v0.0.0-20210422154412-6917c5dd8594 h1:qzmPRDROQ0l0sZI0jMMM79n24aFHu+Z0dPJF3iidwYg=
-github.com/percona/percona-toolkit v0.0.0-20210422154412-6917c5dd8594/go.mod h1:uGrhLglXccEIplDyzQSJfv3UWG5J7ACFjaZebntKStQ=
+github.com/percona/percona-toolkit v0.0.0-20210503082911-610ab8c66a81 h1:3BEeXQbahNJpMioM2PGDpf1RqGQt3UNe0xOPkP93Bco=
+github.com/percona/percona-toolkit v0.0.0-20210503082911-610ab8c66a81/go.mod h1:uGrhLglXccEIplDyzQSJfv3UWG5J7ACFjaZebntKStQ=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/percona/exporter_shared v0.7.2 h1:8eNBht83bgFagdiIm3b4HbsOFc5du6OUBCUVenTumdw=
 github.com/percona/exporter_shared v0.7.2/go.mod h1:AWk9lgTPzI7tC5PzpeBGvhhqjSJNxpPNFaF7qLIJqmo=
 github.com/percona/go-mysql v0.0.0-20190903141930-197f4ad8db8d/go.mod h1:/SGLf9OMxlnK6jq4mkFiImBcJXXk5jwD+lDrwDaGXcw=
-github.com/percona/percona-toolkit v0.0.0-20210504134948-4dd72d96b10d h1:RCnD2c2+ur6z0Lee/VLEXuGT1TKvZs/i3nYrWZ4WrT0=
-github.com/percona/percona-toolkit v0.0.0-20210504134948-4dd72d96b10d/go.mod h1:uGrhLglXccEIplDyzQSJfv3UWG5J7ACFjaZebntKStQ=
+github.com/percona/percona-toolkit v0.0.0-20210422154412-6917c5dd8594 h1:qzmPRDROQ0l0sZI0jMMM79n24aFHu+Z0dPJF3iidwYg=
+github.com/percona/percona-toolkit v0.0.0-20210422154412-6917c5dd8594/go.mod h1:uGrhLglXccEIplDyzQSJfv3UWG5J7ACFjaZebntKStQ=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=


### PR DESCRIPTION
Includes additional information about collection stats about "storage".

```
# HELP mongodb_mydb_mycol_storageStats_avgObjSize mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_avgObjSize untyped
mongodb_mydb_mycol_storageStats_avgObjSize{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 238
# HELP mongodb_mydb_mycol_storageStats_capped mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_capped untyped
mongodb_mydb_mycol_storageStats_capped{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 0
# HELP mongodb_mydb_mycol_storageStats_count mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_count untyped
mongodb_mydb_mycol_storageStats_count{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 57
# HELP mongodb_mydb_mycol_storageStats_freeStorageSize mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_freeStorageSize untyped
mongodb_mydb_mycol_storageStats_freeStorageSize{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 0
# HELP mongodb_mydb_mycol_storageStats_indexSizes_id mydb.mycol.storageStats.indexSizes.
# TYPE mongodb_mydb_mycol_storageStats_indexSizes_id untyped
mongodb_mydb_mycol_storageStats_indexSizes_id{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 20480
# HELP mongodb_mydb_mycol_storageStats_nindexes mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_nindexes untyped
mongodb_mydb_mycol_storageStats_nindexes{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 1
# HELP mongodb_mydb_mycol_storageStats_scaleFactor mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_scaleFactor untyped
mongodb_mydb_mycol_storageStats_scaleFactor{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 1
# HELP mongodb_mydb_mycol_storageStats_size mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_size untyped
mongodb_mydb_mycol_storageStats_size{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 13591
# HELP mongodb_mydb_mycol_storageStats_storageSize mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_storageSize untyped
mongodb_mydb_mycol_storageStats_storageSize{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 20480
# HELP mongodb_mydb_mycol_storageStats_totalIndexSize mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_totalIndexSize untyped
mongodb_mydb_mycol_storageStats_totalIndexSize{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 20480
# HELP mongodb_mydb_mycol_storageStats_totalSize mydb.mycol.storageStats.
# TYPE mongodb_mydb_mycol_storageStats_totalSize untyped
mongodb_mydb_mycol_storageStats_totalSize{cl_id="5f107dfb3a6fc97a81753480",cl_role="shardsvr",collection="mycol",database="mydb",rs_nm="shard-0",rs_state="1"} 40960
```

This is intentionally filtering out any information from `storageStats.wiredTiger` and `storageStats.indexDetails` since it can lead to a high-cardinality issues

```json
db.mycol.aggregate( [ { $collStats: { storageStats: { scale: 1 } } }, { "$project": { "storageStats.wiredTiger": 0, "storageStats.indexDetails": 0 } } ] ).pretty()
{
        "ns" : "mydb.mycol",
        "host" : "localhost:27017",
        "localTime" : ISODate("2021-06-02T02:02:59.173Z"),
        "storageStats" : {
                "size" : 7391055,
                "count" : 48265,
                "avgObjSize" : 153,
                "storageSize" : 4222976,
                "freeStorageSize" : 548864,
                "capped" : false,
                "nindexes" : 3,
                "indexBuilds" : [ ],
                "totalIndexSize" : 5398528,
                "totalSize" : 9621504,
                "indexSizes" : {
                        "_id_" : 2646016,
                        "key_1" : 2183168,
                        "licenseKey_1" : 569344
                },
                "scaleFactor" : 1
        }
}
```

---
- [x] Tests passed.
- [x] Fix conflicts with target branch.
- [x] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.


When all checks have passed and code is ready for the review, bot should add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forums](https://forums.percona.com) and [Discord](https://discord.gg/mQEyGPkNbR).
