### PR TITLE
README - Replace `make build` with `make release`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Currently, these metric sources are implemented:
 
  ### Build the exporter
 The build process uses the dockerized version of goreleaser so you don't need to install Go.
-Just run `make build` and the new binaries will be generated under the build directory.
+Just run `make release` and the new binaries will be generated under the build directory.
 ```
 ├── build
 │ ├── config.yaml


### PR DESCRIPTION
In the README
> The build process uses the dockerized version of goreleaser so you don't need to install Go.
Just run `make build` and the new binaries will be generated under the build directory.

, but it must be `make release`.

---
- [ ] Tests passed.
- [ ] Fix conflicts with target branch.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.


When all checks have passed and code is ready for the review, bot should add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forums](https://forums.percona.com) and [Discord](https://discord.gg/mQEyGPkNbR).
