### PR TITLE
PMM-8849 Fixed panic on nil data

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - 1.16.x
+          - 1.17.x
         image:
           - mongo:3.6
           - mongo:4.0

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -1307,6 +1307,9 @@ func dbstatsMetrics(ctx context.Context, client *mongo.Client, l *logrus.Logger)
 	var metrics []prometheus.Metric
 
 	dbStatList := getDatabaseStatList(ctx, client, l)
+	if dbStatList == nil {
+		return metrics
+	}
 
 	for _, member := range dbStatList.Members {
 		if len(member.Shards) > 0 {


### PR DESCRIPTION
When the data collection was slow for some reason like having a big
number of databases, one of the functions was returning a nil but that
condition was not being checked and a struct field was used causing a
panic.

[PMM-8849: Fixed panic on nil data](https://jira.percona.com/browse/PMM-8849)