### PR TITLE
PMM-5471 add license checks

### DIFF
--- a/.github/check-license.go
+++ b/.github/check-license.go
@@ -51,7 +51,7 @@ var (
 `
 
 	copyrightPattern = regexp.MustCompile(`^// mongodb_exporter
-// Copyright \(C\) \d{4} Percona LLC
+// Copyright \(C\) 20\d{2} Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,3 +83,4 @@ jobs:
           # use GITHUB_TOKEN because only it has access to GitHub Checks API
           bin/golangci-lint run -c=.golangci-required.yml --out-format=line-number | env REVIEWDOG_GITHUB_API_TOKEN=${{ secrets.GITHUB_TOKEN }} bin/reviewdog -f=golangci-lint -level=error -reporter=github-pr-check
           bin/golangci-lint run -c=.golangci.yml --out-format=line-number | env REVIEWDOG_GITHUB_API_TOKEN=${{ secrets.GITHUB_TOKEN }} bin/reviewdog -f=golangci-lint -level=error -reporter=github-pr-review
+          make check-license

--- a/exporter/common.go
+++ b/exporter/common.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/exporter/common.go
+++ b/exporter/common.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package exporter
 
 import (

--- a/exporter/common_test.go
+++ b/exporter/common_test.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/exporter/common_test.go
+++ b/exporter/common_test.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package exporter
 
 import (

--- a/exporter/debug.go
+++ b/exporter/debug.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/exporter/debug.go
+++ b/exporter/debug.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package exporter
 
 import (

--- a/exporter/debug_test.go
+++ b/exporter/debug_test.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/exporter/debug_test.go
+++ b/exporter/debug_test.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package exporter
 
 import (

--- a/exporter/secondary_lag_test.go
+++ b/exporter/secondary_lag_test.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/exporter/secondary_lag_test.go
+++ b/exporter/secondary_lag_test.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package exporter
 
 import (

--- a/exporter/utils_test.go
+++ b/exporter/utils_test.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/exporter/utils_test.go
+++ b/exporter/utils_test.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package exporter
 
 import (

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package exporter
 
 import (

--- a/exporter/v1_compatibility_test.go
+++ b/exporter/v1_compatibility_test.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/exporter/v1_compatibility_test.go
+++ b/exporter/v1_compatibility_test.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package exporter
 
 import (

--- a/internal/tu/docker_inspect.go
+++ b/internal/tu/docker_inspect.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/tu/docker_inspect.go
+++ b/internal/tu/docker_inspect.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package tu
 
 import "time"

--- a/internal/tu/docker_inspect_test.go
+++ b/internal/tu/docker_inspect_test.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package tu
 
 import (

--- a/internal/tu/docker_inspect_test.go
+++ b/internal/tu/docker_inspect_test.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/main_test.go
+++ b/main_test.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/main_test.go
+++ b/main_test.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,5 +1,5 @@
 // mongodb_exporter
-// Copyright (C) 2017 Percona LLC
+// Copyright (C) 2022 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,19 @@
+// mongodb_exporter
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //go:build tools
 // +build tools
 


### PR DESCRIPTION
[PMM-5471 Add license checks to mongodb_exporter](https://jira.percona.com/browse/PMM-5471)

Adds the license header text to all existing go files without one, and include the license checker in CI.