### PR TITLE
exporter: fix collstats compatibility issue

### DIFF
--- a/exporter/collstats_collector.go
+++ b/exporter/collstats_collector.go
@@ -66,8 +66,8 @@ func (d *collstatsCollector) Collect(ch chan<- prometheus.Metric) {
 		aggregation := bson.D{
 			{
 				Key: "$collStats", Value: bson.M{
-					"latencyStats": bson.E{Key: "histograms", Value: true},
-					"storageStats": bson.E{Key: "scale", Value: 1},
+					"latencyStats": bson.M{"histograms": true},
+					"storageStats": bson.M{"scale": 1},
 				},
 			},
 		}

--- a/exporter/collstats_collector.go
+++ b/exporter/collstats_collector.go
@@ -66,7 +66,7 @@ func (d *collstatsCollector) Collect(ch chan<- prometheus.Metric) {
 		aggregation := bson.D{
 			{
 				Key: "$collStats", Value: bson.M{
-					//TODO: PMM-9568 : Add support to handle histogram metrics
+					// TODO: PMM-9568 : Add support to handle histogram metrics
 					"latencyStats": bson.M{"histograms": false},
 					"storageStats": bson.M{"scale": 1},
 				},

--- a/exporter/collstats_collector.go
+++ b/exporter/collstats_collector.go
@@ -66,7 +66,8 @@ func (d *collstatsCollector) Collect(ch chan<- prometheus.Metric) {
 		aggregation := bson.D{
 			{
 				Key: "$collStats", Value: bson.M{
-					"latencyStats": bson.M{"histograms": true},
+					//TODO: PMM-9568 : Add support to handle histogram metrics
+					"latencyStats": bson.M{"histograms": false},
 					"storageStats": bson.M{"scale": 1},
 				},
 			},


### PR DESCRIPTION
`$collStats` is invoked by exporter to get collection statistics from MongoDB. The configuration generated by exporter worked for v4.2 and v4.4 of MongoDB, but failed for v5.0.

This change modifies configuration to work for v4.2, v4.4 and v5.0.

Fixes #432