### PR TITLE
Update test matrix for CI pipeline

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,13 +22,13 @@ jobs:
         go-version:
           - 1.17.x
         image:
-          - mongo:3.6
           - mongo:4.0
           - mongo:4.2
           - mongo:4.4
-          - percona/percona-server-mongodb:3.6
+          - mongo:5.0
           - percona/percona-server-mongodb:4.0
           - percona/percona-server-mongodb:4.2
+          - percona/percona-server-mongodb:4.4
         os: [ubuntu-latest]
         may-fail: [false]
 


### PR DESCRIPTION
Test matrix should test exporter against all versions of MongoDB which are officially supported. Hence MongoDB 5.0 is added. MongoDB 3.6 versions are removed, since they have hit EOL.