### PR TITLE
Fix CI pipeline warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,10 +31,10 @@ linters:
       - wsl
       - exhaustivestruct
       - varnamelen
-      - maligned
-      - scopelint
-      - golint
-      - interfacer
+      - maligned          //deprecated
+      - scopelint         //deprecated
+      - golint            //deprecated
+      - interfacer        //deprecated
 issues:
   exclude-use-default: false
   exclude:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,10 @@ linters:
       - wsl
       - exhaustivestruct
       - varnamelen
+      - maligned
+      - scopelint
+      - golint
+      - interfacer
 issues:
   exclude-use-default: false
   exclude:

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ FILES = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 format:                     ## Format source code.
 	go mod tidy
-	bin/gofumpt -l -w -s $(FILES)
+	bin/gofumpt -l -w $(FILES)
 	bin/goimports -local github.com/percona/mongodb_exporter -l -w $(FILES)
 
 check:                      ## Run checks/linters


### PR DESCRIPTION
This change fixes following warnings noticed in CI pipeline:

**Diff stage**
```
bin/gofumpt -l -w -s ./main.go ./.github/check-license.go ./exporter/topology_info.go ./exporter/general_collector_test.go ./exporter/general_collector.go ./exporter/metrics.go ./exporter/topology_info_test.go ./exporter/collstats_collector.go ./exporter/serverstatus_collector.go ./exporter/diagnostic_data_collector_test.go ./exporter/base_collector.go ./exporter/collstats_collector_test.go ./exporter/dbstats_collector_test.go ./exporter/diagnostic_data_collector.go ./exporter/utils_test.go ./exporter/top_collector_test.go ./exporter/dbstats_collector.go ./exporter/common_test.go ./exporter/v1_compatibility.go ./exporter/debug_test.go ./exporter/v1_compatibility_test.go ./exporter/replset_status_collector.go ./exporter/debug.go ./exporter/exporter.go ./exporter/metrics_test.go ./exporter/exporter_test.go ./exporter/common.go ./exporter/indexstats_collector_test.go ./exporter/replset_status_collector_test.go ./exporter/top_collector.go ./exporter/indexstats_collector.go ./exporter/serverstatus_collector_test.go ./exporter/secondary_lag_test.go ./tools/tools.go ./internal/tu/testutils.go ./internal/tu/docker_inspect.go ./internal/tu/docker_inspect_test.go ./main_test.go
warning: -s is deprecated as it is always enabled
```

**Linter stage**
```
level=warning msg="[runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive."
level=warning msg="[runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref."
level=warning msg="[runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner. "
level=warning msg="[runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  Replaced by govet 'fieldalignment'."
```