### PR TITLE
Update readme regarding `enable.top`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ the current version.
 |\-\-no-collector.diagnosticdata|Disable collecting metrics from getDiagnosticData||
 |\-\-no-collector.replicasetstatus|Disable collecting metrics from replSetGetStatus||
 |\-\-collector.dbstats|Enable collecting metrics from dbStats||
-|\-\-enable.top|Enable collecting metrics from top admin command||
+|\-\-collector.topmetrics|Enable collecting metrics from top admin command||
 |\-\-metrics.overridedescendingindex| Enable descending index name override to replace -1 with _DESC ||
 |--version|Show version and exit|
 


### PR DESCRIPTION
Apparently `enable.top` was renamed to `collector.topmetrics`. This updates the README to reflect that change.
