### PR TITLE
Fix ambiguous postinst option -s

### DIFF
--- a/.scripts/postinst
+++ b/.scripts/postinst
@@ -4,7 +4,7 @@ set -e
 
 echo "Creating user and group..."
 
-adduser -s /sbin/nologin --no-create-home -c "Mongodb Exporter User" mongodb_exporter
+adduser --system --no-create-home -c "Mongodb Exporter User" mongodb_exporter
 
 systemctl daemon-reload > dev/null || exit $?
 


### PR DESCRIPTION
This PR should fix #480. Generally, it's good practice that options should use the full-name format for readability.

Added `--system` option, because it covers nologin shell option + good practice again, non-interactive users for software running on the server should be system users.

---

- [ ] Tests passed.
- [ ] Fix conflicts with target branch.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.

Once all checks pass and the code is ready for review, please add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forum](https://forums.percona.com) or [Discord](https://per.co.na/discord).
