### PR TITLE
Update comments for gotip

### DIFF
--- a/exporter/common.go
+++ b/exporter/common.go
@@ -68,8 +68,10 @@ func listCollections(ctx context.Context, client *mongo.Client, database string,
 
 // databases returns the list of databases matching the filters.
 // - filterInNamespaces: Include only the database names matching the any of the regular expressions in this list.
-//                       Case will be ignored because the function will automatically add the ignore case
-//                       flag to the regular expression.
+//
+//	Case will be ignored because the function will automatically add the ignore case
+//	flag to the regular expression.
+//
 // - exclude: List of databases to be excluded. Useful to ignore system databases.
 func databases(ctx context.Context, client *mongo.Client, filterInNamespaces []string, exclude []string) ([]string, error) {
 	opts := &options.ListDatabasesOptions{NameOnly: pointer.ToBool(true), AuthorizedDatabases: pointer.ToBool(true)}

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -121,16 +121,17 @@ func newToOldMetric(rm *rawMetric, c conversion) *rawMetric {
 // should be converted to mongodb_mongod_wiredtiger_cache_bytes with label "type": "total".
 // For this conversion, we have the suffixMapping field that holds the mapping for all suffixes.
 // Example definition:
-//    oldName:     "mongodb_mongod_wiredtiger_cache_bytes",
-//    prefix:      "mongodb_ss_wt_cache_bytes",
-//    suffixLabel: "type",
-//    suffixMapping: map[string]string{
-//      "bytes_currently_in_the_cache":                           "total",
-//      "tracked_dirty_bytes_in_the_cache":                       "dirty",
-//      "tracked_bytes_belonging_to_internal_pages_in_the_cache": "internal_pages",
-//      "tracked_bytes_belonging_to_leaf_pages_in_the_cache":     "internal_pages",
-//    },
-//   },
+//
+//	 oldName:     "mongodb_mongod_wiredtiger_cache_bytes",
+//	 prefix:      "mongodb_ss_wt_cache_bytes",
+//	 suffixLabel: "type",
+//	 suffixMapping: map[string]string{
+//	   "bytes_currently_in_the_cache":                           "total",
+//	   "tracked_dirty_bytes_in_the_cache":                       "dirty",
+//	   "tracked_bytes_belonging_to_internal_pages_in_the_cache": "internal_pages",
+//	   "tracked_bytes_belonging_to_leaf_pages_in_the_cache":     "internal_pages",
+//	 },
+//	},
 func createOldMetricFromNew(rm *rawMetric, c conversion) *rawMetric {
 	suffix := strings.TrimPrefix(rm.fqName, c.prefix)
 	suffix = strings.TrimPrefix(suffix, "_")

--- a/internal/tu/docker_inspect.go
+++ b/internal/tu/docker_inspect.go
@@ -23,7 +23,7 @@ type HostPort struct {
 	HostPort string `json:"HostPort"`
 }
 
-//nolint
+// nolint
 type DockerInspectOutput []struct {
 	ID      string    `json:"Id"`
 	Created time.Time `json:"Created"`


### PR DESCRIPTION
Comment format has been updated after Go 1.18, which is reflected in tip version of Golang. This patch updates comments to be compliant with new format.
