### PR TITLE
Issue 458 cluster role label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ release:                      ## Build the binaries using goreleaser
 	docker run --rm --privileged \
 		-v ${PWD}:/go/src/github.com/user/repo \
 		-w /go/src/github.com/user/repo \
-		goreleaser/goreleaser release --snapshot --skip-publish --rm-dist
+		goreleaser/goreleaser release --snapshot --skip-publish --rm-dist 
 
 FILES = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 

--- a/exporter/diagnostic_data_collector.go
+++ b/exporter/diagnostic_data_collector.go
@@ -96,7 +96,9 @@ func (d *diagnosticDataCollector) collect(ch chan<- prometheus.Metric) {
 
 		nodeType, err := getNodeType(d.ctx, client)
 		if err != nil {
-			logger.Errorf("Cannot get node type to check if this is a mongos: %s", err)
+			logger.WithFields(logrus.Fields{
+				"component": "diagnosticDataCollector",
+			}).Errorf("Cannot get node type to check if this is a mongos: %s", err)
 		} else if nodeType == typeMongos {
 			metrics = append(metrics, mongosMetrics(d.ctx, client, logger)...)
 		}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -136,7 +136,7 @@ func (e *Exporter) makeRegistry(ctx context.Context, client *mongo.Client, topol
 
 	nodeType, err := getNodeType(ctx, client)
 	if err != nil {
-		e.logger.Errorf("Cannot get node type to check if this is a mongos: %s", err)
+		e.logger.Errorf("Registry - Cannot get node type to check if this is a mongos : %s", err)
 	}
 
 	// Enable collectors like collstats and indexstats depending on the number of collections

--- a/exporter/topology_info.go
+++ b/exporter/topology_info.go
@@ -184,11 +184,6 @@ func getClusterRole(ctx context.Context, client *mongo.Client) (string, error) {
 		return "mongos", nil
 	}
 
-	// standalone
-	if walkTo(cmdOpts, []string{"parsed", "replication", "replSet"}) == nil {
-		return "", nil
-	}
-
 	clusterRole := ""
 	if cr := walkTo(cmdOpts, []string{"parsed", "sharding", "clusterRole"}); cr != nil {
 		clusterRole, _ = cr.(string)


### PR DESCRIPTION
This solves https://github.com/percona/mongodb_exporter/issues/458
It is not easy to reproduce and that's why there are no unit or integration tests but the reporter was able to test this patch and it works.
Sometimes, the `if` block to detect a standalone instance was true, preventing the detection of other cluster roles.
Since we are returning an empty string by default, we can remove the if and have the same behavior without false positives for **standalone** instances.