### PR TITLE
Use direct connection for tests connecting to rs1

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -78,6 +78,7 @@ func TestConnect(t *testing.T) {
 			Logger:         log,
 			URI:            fmt.Sprintf("mongodb://127.0.0.1:%s/admin", tu.MongoDBS1PrimaryPort),
 			GlobalConnPool: false,
+			DirectConnect:  true,
 		}
 
 		e := New(exporterOpts)
@@ -111,6 +112,7 @@ func TestConnect(t *testing.T) {
 			Logger:         log,
 			URI:            fmt.Sprintf("mongodb://127.0.0.1:%s/admin", tu.MongoDBS1PrimaryPort),
 			GlobalConnPool: true,
+			DirectConnect:  true,
 		}
 
 		e := New(exporterOpts)


### PR DESCRIPTION
This facilitates running tests locally as described in the [contributing guide](https://github.com/percona/mongodb_exporter/blob/main/CONTRIBUTING.md#running-tests) via `make test`.

When run outside of the docker network it is not possible to connect to each replica set member so this instructs the driver to connect only to the host provided.

[PMM-10693](https://jira.percona.com/browse/PMM-10693)

- [ ] Links to other linked pull requests (optional).

---

- [x] Tests passed.
- [x] Fix conflicts with target branch.
- [x] Update jira ticket description if needed.
- [x] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.

Once all checks pass and the code is ready for review, please add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forum](https://forums.percona.com) or [Discord](https://per.co.na/discord).
