### PR TITLE
Add support for timestamp metrics with seconds precision

### DIFF
--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -208,7 +208,9 @@ func asFloat64(value interface{}) (*float64, error) {
 		f = v
 	case primitive.DateTime:
 		f = float64(v)
-	case primitive.A, primitive.ObjectID, primitive.Timestamp, primitive.Binary, string, []uint8, time.Time:
+	case primitive.Timestamp:
+		f = float64(v.T)
+	case primitive.A, primitive.ObjectID, primitive.Binary, string, []uint8, time.Time:
 		return nil, nil
 	default:
 		return nil, errors.Wrapf(errCannotHandleType, "%T", v)

--- a/exporter/metrics_test.go
+++ b/exporter/metrics_test.go
@@ -141,7 +141,7 @@ func TestMakeRawMetric(t *testing.T) {
 		{value: float32(1.23), wantVal: pointer.ToFloat64(float64(float32(1.23)))},
 		{value: float64(1.23), wantVal: pointer.ToFloat64(1.23)},
 		{value: primitive.A{}, wantVal: nil},
-		{value: primitive.Timestamp{}, wantVal: nil},
+		{value: primitive.Timestamp{T: 123, I: 456}, wantVal: pointer.ToFloat64(123)},
 		{value: "zapp", wantVal: nil},
 		{value: []byte{}, wantVal: nil},
 		{value: time.Date(2020, 6, 15, 0, 0, 0, 0, time.UTC), wantVal: nil},


### PR DESCRIPTION
This is useful for exporting oplog metrics in order to calculate the oplog window as the difference between `mongodb_ss_oplog_latestOptime` and `mongodb_ss_oplog_earliestOptime`

[PMM-6927](https://jira.percona.com/browse/PMM-6927)

- [ ] Links to other linked pull requests (optional).

---

- [ ] Tests passed.
- [ ] Fix conflicts with target branch.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.

Once all checks pass and the code is ready for review, please add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forum](https://forums.percona.com) or [Discord](https://per.co.na/discord).
