### PR TITLE
Fix connection test issue

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -78,6 +78,7 @@ func TestConnect(t *testing.T) {
 			Logger:         log,
 			URI:            fmt.Sprintf("mongodb://127.0.0.1:%s/admin", tu.MongoDBS1PrimaryPort),
 			GlobalConnPool: false,
+			DirectConnect:  true,
 		}
 
 		e := New(exporterOpts)
@@ -111,6 +112,7 @@ func TestConnect(t *testing.T) {
 			Logger:         log,
 			URI:            fmt.Sprintf("mongodb://127.0.0.1:%s/admin", tu.MongoDBS1PrimaryPort),
 			GlobalConnPool: true,
+			DirectConnect:  true,
 		}
 
 		e := New(exporterOpts)


### PR DESCRIPTION
Connection test were passing on Ubuntu machines but failing on Mac OS machines. Earlier, test would try to connect to all instances of MongoDB in the cluster. This change forces connection to only given MongoDB instance using direct connection configuration option.
