### PR TITLE
PMM-11137 fetch version from buildInfo

### DIFF
--- a/exporter/diagnostic_data_collector_test.go
+++ b/exporter/diagnostic_data_collector_test.go
@@ -292,7 +292,7 @@ func TestDisconnectedDiagnosticDataCollector(t *testing.T) {
 	mongodb_mongod_storage_engine{engine="Engine is unavailable"} 1
 	# HELP mongodb_version_info The server version
 	# TYPE mongodb_version_info gauge
-	mongodb_version_info{edition="",mongodb="server version is unavailable",vendor=""} 1` + "\n")
+	mongodb_version_info{edition="",mongodb="",vendor=""} 1` + "\n")
 	// Filter metrics for 2 reasons:
 	// 1. The result is huge
 	// 2. We need to check against know values. Don't use metrics that return counters like uptime


### PR DESCRIPTION
[PMM-11137](https://jira.percona.com/browse/PMM-11137)

Build: [SUBMODULES-2945](https://github.com/Percona-Lab/pmm-submodules/pull/2945)

Updated existing metric to `mongodb_version_info{edition="Community",mongodb="4.2.23",vendor="MongoDB"}` from `mongodb_version_info{edition="Community",mongodb="server version is unavailable",vendor="MongoDB"}`

Test 1 for **mongos** in docker-compose.yml
```bash
./mongodb_exporter --mongodb.uri=mongodb://localhost:17000 --collector.replicasetstatus=true --log.level=debug --collect-all --web.listen-address=:9219 --compatible-mode=true
```
```bash
browse http://localhost:9219/metrics
```
```text
# HELP mongodb_version_info The server version
# TYPE mongodb_version_info gauge
mongodb_version_info{edition="Community",mongodb="4.2.23",vendor="MongoDB"} 1
```

Test 2 for **mongo-1-1** in docker-compose.yml
```bash
./mongodb_exporter --mongodb.uri=mongodb://localhost:17001 --collector.replicasetstatus=true --log.level=debug --collect-all --web.listen-address=:9220 --compatible-mode=true
```
```bash
browse http://localhost:9220/metrics
```
```text
# HELP mongodb_version_info The server version
# TYPE mongodb_version_info gauge
mongodb_version_info{edition="Community",mongodb="4.2.23",vendor="MongoDB"} 1
```

- [x] Tests passed.
- [x] Fix conflicts with target branch.
- [x] Update jira ticket description if needed.
- [x] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.

Once all checks pass and the code is ready for review, please add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forum](https://forums.percona.com) or [Discord](https://per.co.na/discord).
