### PR TITLE
PMM-11247: Do not create a metric mongodb_mongod_storage_engine if it's not possible to retrieve

### DIFF
--- a/exporter/diagnostic_data_collector_test.go
+++ b/exporter/diagnostic_data_collector_test.go
@@ -96,6 +96,9 @@ func TestDiagnosticDataCollectorWithCompatibleMode(t *testing.T) {
 
 	// The last \n at the end of this string is important
 	expected := strings.NewReader(fmt.Sprintf(`
+	# HELP mongodb_mongod_storage_engine The storage engine used by the MongoDB instance
+	# TYPE mongodb_mongod_storage_engine gauge
+	mongodb_mongod_storage_engine{engine="wiredTiger"} 1
 	# HELP mongodb_version_info The server version
 	# TYPE mongodb_version_info gauge
 	mongodb_version_info{edition="Community",mongodb="%s",vendor="%s"} 1`, version, vendor) + "\n")
@@ -105,6 +108,7 @@ func TestDiagnosticDataCollectorWithCompatibleMode(t *testing.T) {
 	// 2. We need to check against know values. Don't use metrics that return counters like uptime
 	//    or counters like the number of transactions because they won't return a known value to compare
 	filter := []string{
+		"mongodb_mongod_storage_engine",
 		"mongodb_version_info",
 	}
 
@@ -287,9 +291,6 @@ func TestDisconnectedDiagnosticDataCollector(t *testing.T) {
 	# HELP mongodb_mongod_replset_my_state An integer between 0 and 10 that represents the replica state of the current member
 	# TYPE mongodb_mongod_replset_my_state gauge
 	mongodb_mongod_replset_my_state{set=""} 6
-	# HELP mongodb_mongod_storage_engine The storage engine used by the MongoDB instance
-	# TYPE mongodb_mongod_storage_engine gauge
-	mongodb_mongod_storage_engine{engine="Engine is unavailable"} 1
 	# HELP mongodb_version_info The server version
 	# TYPE mongodb_version_info gauge
 	mongodb_version_info{edition="",mongodb="",vendor=""} 1` + "\n")

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -857,7 +857,7 @@ func retrieveMongoDBBuildInfo(ctx context.Context, client *mongo.Client, l *logr
 	return bi, nil
 }
 
-func storageEngine(m bson.M) (prometheus.Metric, error) {
+func storageEngine(m bson.M) (prometheus.Metric, error) { //nolint:ireturn
 	v := walkTo(m, []string{"serverStatus", "storageEngine", "name"})
 	name := "mongodb_mongod_storage_engine"
 	help := "The storage engine used by the MongoDB instance"


### PR DESCRIPTION
Do not create a metric mongodb_mongod_storage_engine if it's not possible to retrieve

For example, we can't get the type of engine for mongos instance. So in this case we can skip creating this metric.

[PMM-11247](https://jira.percona.com/browse/PMM-11247) (optional, if ticket reported)

- https://github.com/Percona-Lab/pmm-submodules/pull/2992

---

- [x] Tests passed.
- [x] Fix conflicts with target branch.
- [x] Update jira ticket description if needed.
- [x] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.

Once all checks pass and the code is ready for review, please add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forum](https://forums.percona.com) or [Discord](https://per.co.na/discord).
