### PR TITLE
Fix mongodb_up not set when instance is down

### DIFF
--- a/exporter/base_collector.go
+++ b/exporter/base_collector.go
@@ -44,7 +44,12 @@ func newBaseCollector(client *mongo.Client, logger *logrus.Logger) *baseCollecto
 func (d *baseCollector) Describe(ctx context.Context, ch chan<- *prometheus.Desc, collect func(mCh chan<- prometheus.Metric)) {
 	select {
 	case <-ctx.Done():
-		return
+		// client is nil when MongoDB is down
+		// in this case, we need general_collector to 'mongodb_up' to 0
+		// general_collector is the only collector registered when client is nil
+		if d.client != nil {
+			return
+		}
 	default:
 	}
 

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -311,13 +311,14 @@ func (e *Exporter) Handler() http.Handler {
 			gatherers = append(gatherers, prometheus.DefaultGatherer)
 		}
 
+		var ti *topologyInfo
 		if client != nil {
 			// Topology can change between requests, so we need to get it every time.
-			ti := newTopologyInfo(ctx, client, e.logger)
-
-			registry := e.makeRegistry(ctx, client, ti, requestOpts)
-			gatherers = append(gatherers, registry)
+			ti = newTopologyInfo(ctx, client, e.logger)
 		}
+
+		registry := e.makeRegistry(ctx, client, ti, requestOpts)
+		gatherers = append(gatherers, registry)
 
 		// Delegate http serving to Prometheus client library, which will call collector.Collect.
 		h := promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{


### PR DESCRIPTION
When a MongoDB instance is down, the exporter does not produce any metrics, while we would expect it to return `mongodb_up 0`. This fix is an attempt to fix issues described in #347, #444 and #483.

It's my first PR on Go code so any feedback would be useful !

Also, sorry if I missed something on the whole PR process, don't hesitate to tell me :sweat_smile: 

---

- [x] Tests passed.
- [x] Fix conflicts with target branch.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.

Once all checks pass and the code is ready for review, please add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forum](https://forums.percona.com) or [Discord](https://per.co.na/discord).
