### PR TITLE
update mongo driver (and support deployments where loadBalanced=true)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/shirou/gopsutil v3.21.8+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
-	go.mongodb.org/mongo-driver v1.10.3
+	go.mongodb.org/mongo-driver v1.11.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,7 @@ github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -257,8 +258,8 @@ github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7Jul
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.mongodb.org/mongo-driver v1.10.3 h1:XDQEvmh6z1EUsXuIkXE9TaVeqHw6SwS1uf93jFs0HBA=
-go.mongodb.org/mongo-driver v1.10.3/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
+go.mongodb.org/mongo-driver v1.11.2 h1:+1v2rDQUWNcGW7/7E0Jvdz51V38XXxJfhzbV17aNHCw=
+go.mongodb.org/mongo-driver v1.11.2/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
[PMM-11825](https://jira.percona.com/browse/PMM-11825) (optional, if ticket reported)

- [ ] Links to other linked pull requests (optional).

---

- [x] Tests passed.
- [x] Fix conflicts with target branch.
- [x] Update jira ticket description if needed.
- [x] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.

Once all checks pass and the code is ready for review, please add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forum](https://forums.percona.com) or [Discord](https://per.co.na/discord).

---

Fixes #412

Serverless atlas deployments set `loadBalanced=true` as a DNS option. For instance:

```
$ host -t txt serverless-test.xxx.mongodb.net
serverless-test.xxx.mongodb.net descriptive text "authSource=admin&loadBalanced=true"
```

When `loadBalanced`is used, mongo-driver v1.10.3 checks [if directConnect flag it set, no matter its value](https://github.com/mongodb/mongo-go-driver/blob/v1.10.3/mongo/options/clientoptions.go#L207). As mongod_exporter `mongodb.direct-connect` has a default value, it is always set. As a result, serverless atlas deployments are not currently supported.

The mongo-driver check has changed in recent versions, [the value is checked as well in v1.11.2](https://github.com/mongodb/mongo-go-driver/blob/v1.11.2/mongo/options/clientoptions.go#L211). Therefore, after updating the mongo-driver version, the exporter will support serverless atlas deployment as long as the flag `--no-mongodb-direct-connect`is set.

Example:

```
$ go run ./main.go --mongodb.uri="mongodb+srv://<credentials>@severless-test.xxx.mongodb.net/?retryWrites=true&w=majority" --collect-all --discovering-mode --collector.collstats-limit=0 --web.listen-address ":9000" --no-mongodb.direct-connect --discovering-mode
```
