### PR TITLE
add license files to packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,3 +98,5 @@ nfpms:
         type: "config|noreplace"
       - src: .scripts/default/mongodb_exporter.example
         dst: /etc/default/mongodb_exporter.example
+      - src: LICENSE
+        dst: /usr/share/doc/mongodb_exporter/LICENSE


### PR DESCRIPTION
It is very important (from the legal point of view) to distribute the license together with binaries.