### PR TITLE
Fix case where users are prefixed with mongodb

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,7 +207,6 @@ func parseURIList(uriList []string) []string {
 }
 
 func buildURI(uri string, user string, password string) string {
-
 	prefix := "mongodb://" // default prefix
 	matchRegexp := regexp.MustCompile(`^mongodb(\+srv)?://`)
 

--- a/main.go
+++ b/main.go
@@ -207,17 +207,26 @@ func parseURIList(uriList []string) []string {
 }
 
 func buildURI(uri string, user string, password string) string {
+
+	prefix := "mongodb://" // default prefix
+	matchRegexp := regexp.MustCompile(`^mongodb(\+srv)?://`)
+
+	// Split the uri prefix if there is any
+	if matchRegexp.MatchString(uri) {
+		uriArray := strings.SplitN(uri, "://", 2)
+		prefix = uriArray[0] + "://"
+		uri = uriArray[1]
+	}
+
 	// IF user@pass not contained in uri AND custom user and pass supplied in arguments
 	// DO concat a new uri with user and pass arguments value
 	if !strings.Contains(uri, "@") && user != "" && password != "" {
-		// trim mongodb:// prefix to handle user and pass logic
-		uri = strings.TrimPrefix(uri, "mongodb://")
 		// add user and pass to the uri
 		uri = fmt.Sprintf("%s:%s@%s", user, password, uri)
 	}
-	if !strings.HasPrefix(uri, "mongodb://") {
-		uri = "mongodb://" + uri
-	}
+
+	// add back prefix after adding the user and pass
+	uri = prefix + uri
 
 	return uri
 }

--- a/main.go
+++ b/main.go
@@ -215,7 +215,7 @@ func buildURI(uri string, user string, password string) string {
 		// add user and pass to the uri
 		uri = fmt.Sprintf("%s:%s@%s", user, password, uri)
 	}
-	if !strings.HasPrefix(uri, "mongodb") {
+	if !strings.HasPrefix(uri, "mongodb://") {
 		uri = "mongodb://" + uri
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -137,6 +137,27 @@ func TestBuildURI(t *testing.T) {
 			newPassword: "yyy",
 			expect:      "mongodb://mongodbxxx:yyy@127.0.0.1",
 		},
+		{
+			situation:   "uri with srv prefix and no auth, auth supplied in opt.User/Password, and user prefixed with mongodb",
+			origin:      "mongodb+srv://127.0.0.1",
+			newUser:     "mongodbxxx",
+			newPassword: "yyy",
+			expect:      "mongodb+srv://mongodbxxx:yyy@127.0.0.1",
+		},
+		{
+			situation:   "uri with srv prefix and auth, auth supplied in opt.User/Password, and user prefixed with mongodb",
+			origin:      "mongodb+srv://xxx:zzz@127.0.0.1",
+			newUser:     "mongodbxxx",
+			newPassword: "yyy",
+			expect:      "mongodb+srv://xxx:zzz@127.0.0.1",
+		},
+		{
+			situation:   "uri with srv prefix and auth, no auth supplied in opt.User/Password, and user prefixed with mongodb",
+			origin:      "mongodb+srv://xxx:zzz@127.0.0.1",
+			newUser:     "",
+			newPassword: "",
+			expect:      "mongodb+srv://xxx:zzz@127.0.0.1",
+		},
 	}
 	for _, tc := range tests {
 		newUri := buildURI(tc.origin, tc.newUser, tc.newPassword)

--- a/main_test.go
+++ b/main_test.go
@@ -123,6 +123,20 @@ func TestBuildURI(t *testing.T) {
 			newPassword: "",
 			expect:      "mongodb://127.0.0.1",
 		},
+		{
+			situation:   "uri with no prefix and no auth, auth supplied in opt.User/Password, and user prefixed with mongodb",
+			origin:      "127.0.0.1",
+			newUser:     "mongodbxxx",
+			newPassword: "yyy",
+			expect:      "mongodb://mongodbxxx:yyy@127.0.0.1",
+		},
+		{
+			situation:   "uri with prefix and no auth, auth supplied in opt.User/Password, and user prefixed with mongodb",
+			origin:      "mongodb://127.0.0.1",
+			newUser:     "mongodbxxx",
+			newPassword: "yyy",
+			expect:      "mongodb://mongodbxxx:yyy@127.0.0.1",
+		},
 	}
 	for _, tc := range tests {
 		newUri := buildURI(tc.origin, tc.newUser, tc.newPassword)


### PR DESCRIPTION
In issue https://github.com/percona/mongodb_exporter/issues/763 a user faced an error when connecting to the uri.

There is a bug when the mongodb user is prefixed with 'mongodb' that prevents the program to add the `mongodb://` uri prefix.