### PR TITLE
PMM-12161 fix rs state wrong metric

### DIFF
--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -917,7 +917,7 @@ func serverVersion(bi buildInfo) prometheus.Metric { //nolint:ireturn
 func myState(ctx context.Context, client *mongo.Client) prometheus.Metric {
 	id, state, err := util.MyState(ctx, client)
 	if err != nil {
-		state = UnknownState
+		return nil
 	}
 
 	name := "mongodb_mongod_replset_my_state"


### PR DESCRIPTION
[PMM-12161](https://jira.percona.com/browse/PMM-12161) 

- Fixes exporter returning status 6 when it cannot read the replica set state. This was a bad design decision and causes mongos routers to return the mongodb_mongod_replset_my_state even though that metric does not make sense for a router. 

[PMM-12161]: https://perconadev.atlassian.net/browse/PMM-12161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ