### PR TITLE
Remove system colections from index stats

### DIFF
--- a/exporter/indexstats_collector.go
+++ b/exporter/indexstats_collector.go
@@ -94,6 +94,11 @@ func (d *indexstatsCollector) collect(ch chan<- prometheus.Metric) {
 		database := parts[0]
 		collection := strings.Join(parts[1:], ".")
 
+		// exclude system collections
+		if strings.HasPrefix(collection, "system.") {
+			continue
+		}
+
 		aggregation := bson.D{
 			{Key: "$indexStats", Value: bson.M{}},
 		}


### PR DESCRIPTION
Details:
When a view is created inside a MongoDB database, a special collection named `system.views` is also created. Attempting to call `IndexStats` on `system.views` results in an `Unauthorized` error, even when executed with root privileges.

For example:

```bash
ERRO[0011] cannot get $indexStats cursor for collection <database>.system.views: 
(Unauthorized) not authorized on <database> to execute command { 
aggregate: "system.views", pipeline: [ { $indexStats: {} } ], cursor: {}, 
lsid: { id: UUID("<lsid>") }, $clusterTime: { clusterTime: Timestamp(<timestamp>, 1), 
signature: { hash: BinData(0, <signature>), keyId: <key-id> } }, $db: "<database>", 
$readPreference: { mode: "primaryPreferred" } }
```

This fix filters out system collections like `system.views` when gathering `IndexStats`, preventing these unnecessary errors from appearing in the logs.
