### PR TITLE
Remove system colections from collstats

### DIFF
--- a/exporter/collstats_collector.go
+++ b/exporter/collstats_collector.go
@@ -92,6 +92,11 @@ func (d *collstatsCollector) collect(ch chan<- prometheus.Metric) {
 		database := parts[0]
 		collection := strings.Join(parts[1:], ".") // support collections having a .
 
+		// exclude system collections
+		if strings.HasPrefix(collection, "system.") {
+			continue
+		}
+		
 		aggregation := bson.D{
 			{
 				Key: "$collStats", Value: bson.M{

--- a/exporter/collstats_collector.go
+++ b/exporter/collstats_collector.go
@@ -96,7 +96,7 @@ func (d *collstatsCollector) collect(ch chan<- prometheus.Metric) {
 		if strings.HasPrefix(collection, "system.") {
 			continue
 		}
-		
+
 		aggregation := bson.D{
 			{
 				Key: "$collStats", Value: bson.M{


### PR DESCRIPTION
See https://github.com/percona/mongodb_exporter/pull/893 When the database profiler is enabled a `system.profile` collection is created for which the collection of collstats is not possible. This results in `Unauthorized` errors.

For example:
```Sep 23 11:39:03 db-01 mongodb_exporter[53912]: time="2024-09-23T11:39:03Z" level=error msg="cannot get $collstats cursor for collection <database>.system.profile: (Unauthorized) not authorized on <database> to execute command { aggregate: \"system.profile\", pipeline: [ { $collStats: { latencyStats: { histograms: false }, storageStats: { scale: 1 } } }, { $project: { storageStats.wiredTiger: 0, storageStats.indexDetails: 0 } } ], cursor: {}, lsid: { id: UUID("<lsid>" }, $clusterTime: { clusterTime: Timestamp(<timestamp>, 1099), signature: { hash: BinData(0, <signature>), keyId: <keyid> } }, $db: \"<database>\" }" collector=collstats```

Should be safe to filter out system collection when gathering collstats as it was already done for the indexstats collector.