### PR TITLE
mongodb_mongod_wiredtiger_cache_max_bytes -> mongodb_ss_wt_cache_maximum_bytes_configured (oldName and newName)

### DIFF
--- a/exporter/diagnostic_data_collector_test.go
+++ b/exporter/diagnostic_data_collector_test.go
@@ -230,7 +230,6 @@ func TestAllDiagnosticDataCollectorMetrics(t *testing.T) {
 		"mongodb_mongod_wiredtiger_cache_bytes",
 		"mongodb_mongod_wiredtiger_transactions_total",
 		"mongodb_mongod_wiredtiger_cache_bytes_total",
-		"mongodb_mongod_wiredtiger_cache_max_bytes",
 		"mongodb_op_counters_total",
 		"mongodb_ss_mem_resident",
 		"mongodb_ss_mem_virtual",
@@ -238,6 +237,7 @@ func TestAllDiagnosticDataCollectorMetrics(t *testing.T) {
 		"mongodb_ss_metrics_getLastError_wtime_totalMillis",
 		"mongodb_ss_opcounters",
 		"mongodb_ss_opcountersRepl",
+		"mongodb_ss_wt_cache_maximum_bytes_configured",
 		"mongodb_ss_wt_cache_modified_pages_evicted",
 	}
 	actualMetrics = filterMetrics(actualMetrics, filters)

--- a/exporter/diagnostic_data_collector_test.go
+++ b/exporter/diagnostic_data_collector_test.go
@@ -230,6 +230,7 @@ func TestAllDiagnosticDataCollectorMetrics(t *testing.T) {
 		"mongodb_mongod_wiredtiger_cache_bytes",
 		"mongodb_mongod_wiredtiger_transactions_total",
 		"mongodb_mongod_wiredtiger_cache_bytes_total",
+		"mongodb_mongod_wiredtiger_cache_max_bytes",
 		"mongodb_op_counters_total",
 		"mongodb_ss_mem_resident",
 		"mongodb_ss_mem_virtual",
@@ -237,7 +238,6 @@ func TestAllDiagnosticDataCollectorMetrics(t *testing.T) {
 		"mongodb_ss_metrics_getLastError_wtime_totalMillis",
 		"mongodb_ss_opcounters",
 		"mongodb_ss_opcountersRepl",
-		"mongodb_ss_wt_cache_maximum_bytes_configured",
 		"mongodb_ss_wt_cache_modified_pages_evicted",
 	}
 	actualMetrics = filterMetrics(actualMetrics, filters)

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -436,6 +436,10 @@ var conversions = []conversion{
 		suffixLabel: "type",
 	},
 	{
+		oldName: "mongodb_mongod_wiredtiger_cache_max_bytes",
+		newName: "mongodb_ss_wt_cache_maximum_bytes_configured",
+	},
+	{
 		oldName: "mongodb_mongod_wiredtiger_cache_overhead_percent",
 		newName: "mongodb_ss_wt_cache_percentage_overhead",
 	},
@@ -643,10 +647,6 @@ var conversions = []conversion{
 	{
 		oldName: "mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds",
 		newName: "mongodb_ss_metrics_getLastError_wtime_totalMillis",
-	},
-	{
-		oldName: "mongodb_mongod_wiredtiger_cache_max_bytes",
-		newName: "mongodb_ss_wt_cache_maximum_bytes_configured",
 	},
 	{
 		oldName: "mongodb_mongod_db_collections_total",

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -649,8 +649,8 @@ var conversions = []conversion{
 		newName: "mongodb_ss_metrics_getLastError_wtime_totalMillis",
 	},
 	{
-		oldName: "mongodb_ss_wt_cache_maximum_bytes_configured",
-		newName: "mongodb_mongod_wiredtiger_cache_max_bytes",
+		oldName: "mongodb_mongod_wiredtiger_cache_max_bytes",
+		newName: "mongodb_ss_wt_cache_maximum_bytes_configured",
 	},
 	{
 		oldName: "mongodb_mongod_db_collections_total",

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -436,10 +436,6 @@ var conversions = []conversion{
 		suffixLabel: "type",
 	},
 	{
-		oldName: "mongodb_mongod_wiredtiger_cache_max_bytes",
-		newName: "mongodb_ss_wt_cache_maximum_bytes_configured",
-	},
-	{
 		oldName: "mongodb_mongod_wiredtiger_cache_overhead_percent",
 		newName: "mongodb_ss_wt_cache_percentage_overhead",
 	},


### PR DESCRIPTION
Looks like they're mixed up.
Fixed mess with oldName and newName for mongodb_ss_wt_cache_maximum_bytes_configured
