### PR TITLE
PMM-7: use credentials for authenticated mongo instance

### DIFF
--- a/exporter/multi_target_test.go
+++ b/exporter/multi_target_test.go
@@ -44,7 +44,7 @@ func TestMultiTarget(t *testing.T) {
 			ConnectTimeoutMS: 1000,
 		},
 		{
-			URI:              fmt.Sprintf("mongodb://%s", net.JoinHostPort(hostname, tu.GetenvDefault("TEST_MONGODB_S2_PRIMARY_PORT", "17004"))),
+			URI:              fmt.Sprintf("mongodb://admin:admin@%s", net.JoinHostPort(hostname, tu.GetenvDefault("TEST_MONGODB_S2_PRIMARY_PORT", "17004"))),
 			DirectConnect:    true,
 			ConnectTimeoutMS: 1000,
 		},


### PR DESCRIPTION
The multi-instance tests connects to multiple mongo instances in our test setup; one of them requires credentials but the test doesn't pass in any. This results in the following error:

```
time="2025-02-11T10:58:15+01:00" level=warning msg="cannot load topology labels: error getting cluster ID: (Unauthorized) command replSetGetConfig requires authentication: cannot get topology labels"
```
