### PR TITLE
fix dpkg postinst adduser error in Debian 12.10

### DIFF
--- a/.scripts/postinst
+++ b/.scripts/postinst
@@ -4,7 +4,7 @@ set -e
 
 echo "Creating user and group..."
 
-adduser --system --no-create-home -c "Mongodb Exporter User" mongodb_exporter
+adduser --system --no-create-home --comment "Mongodb Exporter User" mongodb_exporter
 
 systemctl daemon-reload > dev/null || exit $?
 


### PR DESCRIPTION

Setting up mongodb_exporter (0.43.1) ...
Creating user and group...
**invalid characters in Mongodb Exporter User at /usr/share/perl5/Debian/AdduserCommon.pm line 141. dpkg: error processing** package mongodb_exporter (--configure):
 installed mongodb_exporter package post-installation script subprocess returned error exit status 255


