### PR TITLE
Cache prometheusize rename between scrapes

### DIFF
--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -173,7 +173,7 @@ func prometheusize(s string) string {
 	if renamed, exists := prometheusizeCache[s]; exists {
 		return renamed
 	}
-	back := strings.Clone(s)
+	backup := strings.Clone(s)
 
 	for _, pair := range prefixes {
 		if strings.HasPrefix(s, pair[0]+".") {
@@ -186,10 +186,10 @@ func prometheusize(s string) string {
 	s = dollarRe.ReplaceAllString(s, "")
 	s = repeatedUnderscoresRe.ReplaceAllString(s, "_")
 	s = strings.TrimPrefix(s, "_")
+	s = exporterPrefix + s
 
-	prometheusizeCache[back] = strings.Clone(s)
-
-	return exporterPrefix + s
+	prometheusizeCache[backup] = strings.Clone(s)
+	return s
 }
 
 // nameAndLabel checks if there are predefined metric name and label for that metric or

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -164,10 +164,17 @@ var (
 	dollarRe              = regexp.MustCompile(`\_$`)
 )
 
+var prometheusizeCache = make(map[string]string)
+
 // prometheusize renames metrics by replacing some prefixes with shorter names
 // replace special chars to follow Prometheus metric naming rules and adds the
 // exporter name prefix.
 func prometheusize(s string) string {
+	if renamed, exists := prometheusizeCache[s]; exists {
+		return renamed
+	}
+	back := strings.Clone(s)
+
 	for _, pair := range prefixes {
 		if strings.HasPrefix(s, pair[0]+".") {
 			s = pair[1] + strings.TrimPrefix(s, pair[0])
@@ -179,6 +186,8 @@ func prometheusize(s string) string {
 	s = dollarRe.ReplaceAllString(s, "")
 	s = repeatedUnderscoresRe.ReplaceAllString(s, "_")
 	s = strings.TrimPrefix(s, "_")
+
+	prometheusizeCache[back] = strings.Clone(s)
 
 	return exporterPrefix + s
 }


### PR DESCRIPTION
After profiling the exporter because it had a somewhat high cpu usage, it reported that the regexp operations in this function accounts for more than 10% of the cpu time. 

More precisely, the first call to prometheusize uses 3.79%, the second 5.86% (in exporter.MakeMetrics) and lastly it 1.03% (in exporter.MakeRawMetrics)

This all goes to zero if we cache them.