### PR TITLE
PMM-7: drop mongo 4.4 from CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,16 +23,15 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - mongo:4.4
           - mongo:5.0
           - mongo:6.0
           - mongo:7.0
           - mongo:8.0
           - mongo:latest
-          - percona/percona-server-mongodb:4.4
           - percona/percona-server-mongodb:5.0
           - percona/percona-server-mongodb:6.0
           - percona/percona-server-mongodb:7.0
+          - percona/percona-server-mongodb:8.0
           - percona/percona-server-mongodb:latest
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
This drops PSMDB/Mongo 4.4 images from our CI workflows since they've both been EOL for over a year and no longer supported.