### PR TITLE
[fix] delete endpoint /debug

### DIFF
--- a/exporter/server.go
+++ b/exporter/server.go
@@ -45,7 +45,7 @@ type ServerOpts struct {
 
 // RunWebServer runs the main web-server
 func RunWebServer(opts *ServerOpts, exporters []*Exporter, log *slog.Logger) {
-	mux := http.DefaultServeMux
+	mux := http.NewServeMux()
 
 	if len(exporters) == 0 {
 		panic("No exporters were built. You must specify --mongodb.uri command argument or MONGODB_URI environment variable")


### PR DESCRIPTION
This MR proposes the removal of the default /debug endpoint, which is automatically registered by the net/http standard library. The /debug endpoint exposes debugging information that may include sensitive data, posing a potential security risk in production environments.

Key changes:
1. Removed the registration of the /debug handler via http.DefaultServeMux.

Benefits:
1. Eliminates a potential security vulnerability related to the exposure of debugging information.
2. Reduces the risk of data leakage in production environments.
3. Please review the changes and provide feedback.