### PR TITLE
Fix timeseries collections being ignored in discovery mode

### DIFF
--- a/exporter/common.go
+++ b/exporter/common.go
@@ -60,7 +60,9 @@ func listCollections(ctx context.Context, client *mongo.Client, database string,
 	}
 
 	if skipViews {
-		filter = append(filter, primitive.E{Key: "type", Value: "collection"})
+		filter = append(filter, primitive.E{Key: "type", Value: bson.D{
+			{Key: "$in", Value: bson.A{"collection", "timeseries"}},
+		}})
 	}
 
 	collections, err := client.Database(database).ListCollectionNames(ctx, filter, opts)


### PR DESCRIPTION
The filter excluding view collections erronously also dropped collections with type "timeseries". This caused metrics from timeseries collections to not be collected (including basic ones, like mongotop and index accesses).

