### PR TITLE
Fix duplicate getDiagnosticData error in shard cluster with shard/configsvr replset have more than 1 repl instance situation

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -249,7 +249,7 @@ func (e *Exporter) makeRegistry(ctx context.Context, client *mongo.Client, topol
 		registry.MustRegister(rsgsc)
 	}
 	if e.opts.EnableShards && nodeType == typeMongos && requestOpts.EnableShards {
-		sc := newShardsCollector(ctx, client, e.opts.Logger, e.opts.CompatibleMode)
+		sc := newShardsCollector(ctx, client, e.opts.Logger, e.opts.CompatibleMode, limitsOk)
 		registry.MustRegister(sc)
 	}
 

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -391,7 +391,7 @@ func processSlice(prefix string, v []interface{}, commonLabels map[string]string
 			continue
 		}
 
-		// use the replicaset or server name as a label
+		// use the replicaset or server name or addr as a label
 		if name, ok := s["name"].(string); ok {
 			labels["member_idx"] = name
 		}
@@ -400,6 +400,9 @@ func processSlice(prefix string, v []interface{}, commonLabels map[string]string
 		}
 		if host, ok := s["host"].(string); ok {
 			labels["member_idx"] = host
+		}
+		if addr, ok := s["addr"].(string); ok {
+			labels["member_addr"] = addr
 		}
 
 		metrics = append(metrics, makeMetrics(prefix, s, labels, compatibleMode)...)

--- a/exporter/shards_collector.go
+++ b/exporter/shards_collector.go
@@ -80,12 +80,13 @@ func (d *shardsCollector) collect(ch chan<- prometheus.Metric) {
 		ch <- metric
 	}
 
+	if !d.scanEachCollChunkOk {
+		return
+	}
+
 	databaseNames, err := client.ListDatabaseNames(d.ctx, bson.D{})
 	if err != nil {
 		logger.Error("cannot get database names", "error", err)
-	}
-	if !d.scanEachCollChunkOk {
-		return
 	}
 	for _, database := range databaseNames {
 		collections := d.getCollectionsForDBName(database)

--- a/exporter/shards_collector_test.go
+++ b/exporter/shards_collector_test.go
@@ -35,7 +35,7 @@ func TestShardsCollector(t *testing.T) {
 	defer cancel()
 
 	client := tu.DefaultTestClientMongoS(ctx, t)
-	c := newShardsCollector(ctx, client, promslog.New(&promslog.Config{}), false)
+	c := newShardsCollector(ctx, client, promslog.New(&promslog.Config{}), false, true)
 
 	reg := prometheus.NewPedanticRegistry()
 	if err := reg.Register(c); err != nil {

--- a/exporter/testdata/get_diagnostic_data.json
+++ b/exporter/testdata/get_diagnostic_data.json
@@ -2133,6 +2133,65 @@
       "uri": "statistics:"
     }
   },
+  "connPoolStats" : {
+    "start" : "2025-08-04T07:10:00.002Z",
+    "numClientConnections" : 24,
+    "numAScopedConnections" : 0,
+    "totalInUse" : 0,
+    "totalAvailable" : 156,
+    "totalCreated" : 143694,
+    "totalRefreshing" : 0,
+    "replicaSets" : {
+      "shard_001" : {
+        "hosts" : [
+          {
+            "addr" : "1.1.1.1:36001",
+            "ok" : true,
+            "ismaster" : true,
+            "hidden" : false,
+            "secondary" : false,
+            "pingTimeMillis" : 0
+          },
+          {
+            "addr" : "2.2.2.2:36001",
+            "ok" : true,
+            "ismaster" : false,
+            "hidden" : false,
+            "secondary" : true,
+            "pingTimeMillis" : 0
+          }
+        ]
+      },
+      "configsvr" : {
+        "hosts" : [
+          {
+            "addr" : "3.3.3.3:27001",
+            "ok" : true,
+            "ismaster" : true,
+            "hidden" : false,
+            "secondary" : false,
+            "pingTimeMillis" : 0
+          },
+          {
+            "addr" : "4.4.4.4:27001",
+            "ok" : true,
+            "ismaster" : false,
+            "hidden" : false,
+            "secondary" : true,
+            "pingTimeMillis" : 0
+          },
+          {
+            "addr" : "5.5.5.5:27001",
+            "ok" : true,
+            "ismaster" : false,
+            "hidden" : false,
+            "secondary" : true,
+            "pingTimeMillis" : 0
+          }
+        ]
+      }
+    }
+  },
   "start": "2020-09-10T14:39:52-03:00",
   "systemMetrics": {
     "cpu": {

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ type GlobalFlags struct {
 
 	CollectAll bool `name:"collect-all" help:"Enable all collectors. Same as specifying all --collector.<name>"`
 
-	CollStatsLimit         int  `name:"collector.collstats-limit" help:"Disable collstats, dbstats, topmetrics and indexstats collector if there are more than <n> collections. 0=No limit" default:"0"`
+	CollStatsLimit         int  `name:"collector.collstats-limit" help:"Disable collstats, dbstats, topmetrics, indexstats collector and coll chunk info if there are more than <n> collections. 0=No limit" default:"0"`
 	CollStatsEnableDetails bool `name:"collector.collstats-enable-details" help:"Enable collecting index details and wired tiger metrics from $collStats" default:"false"`
 
 	ProfileTimeTS int `name:"collector.profile-time-ts" help:"Set time for scrape slow queries." default:"30"`


### PR DESCRIPTION

- [mongodb_connPoolStats_replicaSets_{replName}_{childM}_{childMX} collect failed](https://github.com/percona/mongodb_exporter/issues/1125)

---

Below we provide a basic checklist of things that would make it a good PR:
- Make sure to sign the CLA (Contributor License Agreement).
- Make sure all tests pass.
- Keep current with the target branch and fix conflicts if necessary.
- Update jira ticket description if necessary.
- Attach screenshots and/or console output to the jira ticket to confirm new behavior, if applicable.
- Leave notes to the reviewers if you need to focus their attention on something specific.

Once all checks pass and the code is ready for review, please add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forum](https://forums.percona.com).
