### PR TITLE
fix metrics named by mongodb_connPoolStats_replicaSets_{shardReplSetN…

### DIFF
--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -391,7 +391,7 @@ func processSlice(prefix string, v []interface{}, commonLabels map[string]string
 			continue
 		}
 
-		// use the replicaset or server name as a label
+		// use the replicaset or server name or addr as a label
 		if name, ok := s["name"].(string); ok {
 			labels["member_idx"] = name
 		}
@@ -400,6 +400,9 @@ func processSlice(prefix string, v []interface{}, commonLabels map[string]string
 		}
 		if host, ok := s["host"].(string); ok {
 			labels["member_idx"] = host
+		}
+		if addr, ok := s["addr"].(string); ok {
+			labels["member_addr"] = addr
 		}
 
 		metrics = append(metrics, makeMetrics(prefix, s, labels, compatibleMode)...)

--- a/exporter/testdata/get_diagnostic_data.json
+++ b/exporter/testdata/get_diagnostic_data.json
@@ -2133,6 +2133,65 @@
       "uri": "statistics:"
     }
   },
+  "connPoolStats" : {
+    "start" : "2025-08-04T07:10:00.002Z",
+    "numClientConnections" : 24,
+    "numAScopedConnections" : 0,
+    "totalInUse" : 0,
+    "totalAvailable" : 156,
+    "totalCreated" : 143694,
+    "totalRefreshing" : 0,
+    "replicaSets" : {
+      "shard_001" : {
+        "hosts" : [
+          {
+            "addr" : "1.1.1.1:36001",
+            "ok" : true,
+            "ismaster" : true,
+            "hidden" : false,
+            "secondary" : false,
+            "pingTimeMillis" : 0
+          },
+          {
+            "addr" : "2.2.2.2:36001",
+            "ok" : true,
+            "ismaster" : false,
+            "hidden" : false,
+            "secondary" : true,
+            "pingTimeMillis" : 0
+          }
+        ]
+      },
+      "configsvr" : {
+        "hosts" : [
+          {
+            "addr" : "3.3.3.3:27001",
+            "ok" : true,
+            "ismaster" : true,
+            "hidden" : false,
+            "secondary" : false,
+            "pingTimeMillis" : 0
+          },
+          {
+            "addr" : "4.4.4.4:27001",
+            "ok" : true,
+            "ismaster" : false,
+            "hidden" : false,
+            "secondary" : true,
+            "pingTimeMillis" : 0
+          },
+          {
+            "addr" : "5.5.5.5:27001",
+            "ok" : true,
+            "ismaster" : false,
+            "hidden" : false,
+            "secondary" : true,
+            "pingTimeMillis" : 0
+          }
+        ]
+      }
+    }
+  },
   "start": "2020-09-10T14:39:52-03:00",
   "systemMetrics": {
     "cpu": {


### PR DESCRIPTION
- [mongodb_connPoolStats_replicaSets_{replName}_{childM}_{childMX} collect failed](https://github.com/percona/mongodb_exporter/issues/1125)

---

Below we provide a basic checklist of things that would make it a good PR:
- Make sure to sign the CLA (Contributor License Agreement).
- Make sure all tests pass.
- Keep current with the target branch and fix conflicts if necessary.
- Update jira ticket description if necessary.
- Attach screenshots and/or console output to the jira ticket to confirm new behavior, if applicable.
- Leave notes to the reviewers if you need to focus their attention on something specific.

Once all checks pass and the code is ready for review, please add `pmm-review-exporters` team as the reviewer. That would assign people from the review team automatically. Report any issues on our [Forum](https://forums.percona.com).
