### PR TITLE
Fix: Skip the non-exist namespaces when there are multiple mongo instance metrics to scrape

### DIFF
--- a/exporter/common.go
+++ b/exporter/common.go
@@ -164,7 +164,7 @@ func unique(slice []string) []string {
 }
 
 func checkNamespacesForViews(ctx context.Context, client *mongo.Client, collections []string) ([]string, error) {
-	onlyCollectionsNamespaces, err := listAllCollections(ctx, client, nil, nil, true)
+	onlyCollectionsNamespaces, err := listAllCollections(ctx, client, collections, nil, true)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func checkNamespacesForViews(ctx context.Context, client *mongo.Client, collecti
 		}
 
 		if _, ok := namespaces[collection]; !ok {
-			return nil, errors.Errorf("namespace %s is a view and cannot be used for collstats/indexstats", collection)
+			continue
 		}
 
 		filteredCollections = append(filteredCollections, collection)

--- a/exporter/common_test.go
+++ b/exporter/common_test.go
@@ -199,8 +199,9 @@ func TestCheckNamespacesForViews(t *testing.T) {
 	defer cleanupDB(ctx, client)
 
 	t.Run("Views in provided collection list (should fail)", func(t *testing.T) {
-		_, err := checkNamespacesForViews(ctx, client, []string{"testdb01.col01", "testdb01.system.views", "testdb01.view01"})
-		assert.EqualError(t, err, "namespace testdb01.view01 is a view and cannot be used for collstats/indexstats")
+		filtered, err := checkNamespacesForViews(ctx, client, []string{"testdb01.col01", "testdb01.system.views", "testdb01.view01"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"testdb01.col01", "testdb01.system.views"}, filtered)
 	})
 
 	t.Run("No Views in provided collection list", func(t *testing.T) {


### PR DESCRIPTION
Refer to this issue: #1144 

Changes:
1. skip the non-exist namespaces when there are multiple mongo instance metrics to scrape
2. by the way  the listAllCollections(ctx, client, collections, nil, true) need to pass collections as the third parameter to reduce the databases and collections to list, wihich can improve the performance
