### PR TITLE
Make mongodb_exporter user creation idempotent in postinst script

### DIFF
--- a/.scripts/postinst
+++ b/.scripts/postinst
@@ -2,13 +2,15 @@
 
 set -e
 
-echo "Creating user and group..."
-
-useradd --system \
+# creating mongodb_exporter user if he isn't already there
+if ! getent passwd mongodb_exporter >/dev/null; then
+    useradd \
+        --system \
         --no-create-home \
         --shell /sbin/nologin \
         --comment "MongoDB Exporter" \
-        mongodb_exporter
+        mongodb_exporter >/dev/null
+fi
 
 systemctl --system daemon-reload >/dev/null || true
 


### PR DESCRIPTION
The previous postinst script unconditionally ran `useradd` to create the `mongodb_exporter` system user.

That would fail if the user already existed (e.g., during package upgrade), breaking the post-install process.