### PR TITLE
Use systemctl --system daemon-reload and ignore errors in postinst

### DIFF
--- a/.scripts/postinst
+++ b/.scripts/postinst
@@ -10,6 +10,6 @@ useradd --system \
         --comment "MongoDB Exporter" \
         mongodb_exporter
 
-systemctl daemon-reload > dev/null || exit $?
+systemctl --system daemon-reload >/dev/null || true
 
 exit 0


### PR DESCRIPTION
Ensures the postinst script does not fail if daemon-reload returns a non-zero exit code.   Uses the `--system` flag to explicitly target the system manager, following the common pattern in other Debian packages.
