### PR TITLE
feat: Add buildx support in goreleaser configuration for amd64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,7 @@ dockers:
   - "ghcr.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}-amd64"
   - "ghcr.io/percona/mongodb_exporter:{{.Version}}-amd64"
   dockerfile: Dockerfile
+  use: buildx
   build_flag_templates:
     - "--pull"
     - "--platform=linux/amd64"


### PR DESCRIPTION
# Summary
Fix the release pipeline

**Issue:** https://github.com/percona/mongodb_exporter/issues/1241

## TODO
- [x] Execute the goreleaser config (dry run)