### PR TITLE
PMM-15047 Update base image to alpine 3.23.4 with specific SHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine AS builder
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS builder
 RUN apk add --no-cache ca-certificates
 
 FROM scratch AS final


### PR DESCRIPTION
It's recommended to pin the version of base images inside of Docker containers. Using a dynamic version can cause unexpected behavior and at worst, can lead to supply chain attacks. On top of that the 'latest' tag does not always automatically refer to the newest version of the image, so it can also lead to using an outdated version of the base image.

re: https://perconadev.atlassian.net/browse/PMM-15047
