### PR TITLE
Redact MongoDB URI credentials before logging them

### DIFF
--- a/exporter/pbm_collector.go
+++ b/exporter/pbm_collector.go
@@ -27,6 +27,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/percona/mongodb_exporter/internal/proto"
+	"github.com/percona/mongodb_exporter/internal/redact"
 	"github.com/percona/mongodb_exporter/internal/util"
 )
 
@@ -87,7 +88,7 @@ func (p *pbmCollector) collect(ch chan<- prometheus.Metric) {
 	pbmEnabledMetric := 0
 	pbmClient, err := sdk.NewClient(p.ctx, p.mongoURI)
 	if err != nil {
-		logger.Warn("failed to create PBM client", "error", err.Error())
+		logger.Warn("failed to create PBM client", "error", redact.Error(err))
 		return
 	}
 	defer func() {
@@ -136,7 +137,8 @@ func (p *pbmCollector) collect(ch chan<- prometheus.Metric) {
 func (p *pbmCollector) pbmAgentMetrics(ctx context.Context, pbmClient *sdk.Client, l *slog.Logger, currentNode *proto.HelloResponse) []prometheus.Metric {
 	clusterStatus, err := cli.ClusterStatus(ctx, pbmClient, cli.RSConfGetter(p.mongoURI))
 	if err != nil {
-		l.Error("failed to get cluster status", "error", err.Error())
+		// PBM wraps the URI it was handed into this error, so it cannot be logged as it comes.
+		l.Error("failed to get cluster status", "error", redact.Error(err))
 		return nil
 	}
 

--- a/exporter/seedlist.go
+++ b/exporter/seedlist.go
@@ -30,7 +30,9 @@ import (
 func GetSeedListFromSRV(uri string, logger *slog.Logger) string { //nolint:cyclop
 	uriParsed, err := url.Parse(uri)
 	if err != nil {
-		log.Fatalf("Failed to parse URI %s: %v", redact.MongoURI(uri), redact.Error(err))
+		// The parse error is not logged: it quotes the URI cut short at the byte url.Parse choked
+		// on, and when that byte is "?" or "#" from the password, the quote keeps the part before.
+		log.Fatalf("Failed to parse URI %s", redact.MongoURI(uri))
 	}
 
 	cname, srvRecords, err := net.LookupSRV("mongodb", "tcp", uriParsed.Hostname())

--- a/exporter/seedlist.go
+++ b/exporter/seedlist.go
@@ -22,23 +22,25 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/percona/mongodb_exporter/internal/redact"
 )
 
 // GetSeedListFromSRV converts mongodb+srv URI to flat connection string.
 func GetSeedListFromSRV(uri string, logger *slog.Logger) string { //nolint:cyclop
 	uriParsed, err := url.Parse(uri)
 	if err != nil {
-		log.Fatalf("Failed to parse URI %s: %v", uri, err)
+		log.Fatalf("Failed to parse URI %s: %v", redact.MongoURI(uri), redact.Error(err))
 	}
 
 	cname, srvRecords, err := net.LookupSRV("mongodb", "tcp", uriParsed.Hostname())
 	if err != nil {
-		logger.Error("Failed to lookup SRV records", "uri", uri, "error", err)
+		logger.Error("Failed to lookup SRV records", "uri", redact.MongoURI(uri), "error", err)
 		return uri
 	}
 
 	if len(srvRecords) == 0 {
-		logger.Error("No SRV records found", "uri", uri)
+		logger.Error("No SRV records found", "uri", redact.MongoURI(uri))
 		return uri
 	}
 

--- a/exporter/server.go
+++ b/exporter/server.go
@@ -28,6 +28,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/exporter-toolkit/web"
+
+	"github.com/percona/mongodb_exporter/internal/redact"
 )
 
 // ServerMap stores http handlers for each host
@@ -178,7 +180,7 @@ func buildServerMap(exporters []*Exporter, log *slog.Logger) ServerMap {
 		if parsedURL, err := url.Parse(e.opts.URI); err == nil {
 			servers[parsedURL.Host] = e.Handler()
 		} else {
-			log.Error("Unable to parse provided address as url", "address", e.opts.URI, "error", err)
+			log.Error("Unable to parse provided address as url", "address", redact.MongoURI(e.opts.URI), "error", redact.Error(err))
 		}
 	}
 

--- a/exporter/server.go
+++ b/exporter/server.go
@@ -180,7 +180,10 @@ func buildServerMap(exporters []*Exporter, log *slog.Logger) ServerMap {
 		if parsedURL, err := url.Parse(e.opts.URI); err == nil {
 			servers[parsedURL.Host] = e.Handler()
 		} else {
-			log.Error("Unable to parse provided address as url", "address", redact.MongoURI(e.opts.URI), "error", redact.Error(err))
+			// The parse error is not logged: it quotes the URI cut short at the byte url.Parse
+			// choked on, and when that byte is "?" or "#" from the password, the quote keeps the
+			// part before.
+			log.Error("Unable to parse provided address as url", "address", redact.MongoURI(e.opts.URI))
 		}
 	}
 

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,52 @@
+// mongodb_exporter
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package redact hides the credentials embedded in MongoDB connection URIs before they are logged.
+package redact
+
+import (
+	"net/url"
+	"regexp"
+)
+
+// credentialsRE matches the userinfo of a MongoDB connection URI that carries a password. It is
+// used when url.Parse is of no help: either the URI is malformed, or it is quoted inside a longer
+// string such as an error message.
+var credentialsRE = regexp.MustCompile(`(mongodb(?:\+srv)?://)([^\s/?#]*):([^\s/?#]*)@`)
+
+// replacement keeps the scheme and the user name and drops the password. It matches what
+// (*url.URL).Redacted does.
+const replacement = "${1}${2}:xxxxx@"
+
+// MongoURI returns uri with its password replaced by a placeholder, so that it is safe to log.
+func MongoURI(uri string) string {
+	parsed, err := url.Parse(uri)
+	if err == nil && parsed.User != nil {
+		return parsed.Redacted()
+	}
+
+	return credentialsRE.ReplaceAllString(uri, replacement)
+}
+
+// Error returns the message of err with the password of any MongoDB URI it quotes replaced by a
+// placeholder. url.Parse and the MongoDB driver embed the offending URI in their error messages,
+// so logging the error alone is enough to leak the credentials.
+func Error(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return credentialsRE.ReplaceAllString(err.Error(), replacement)
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -24,7 +24,14 @@ import (
 // credentialsRE matches the userinfo of a MongoDB connection URI that carries a password. It is
 // used when url.Parse is of no help: either the URI is malformed, or it is quoted inside a longer
 // string such as an error message.
-var credentialsRE = regexp.MustCompile(`(mongodb(?:\+srv)?://)([^\s/?#]*):([^\s/?#]*)@`)
+//
+// The password group is deliberately permissive and greedy. A password may legally contain any of
+// "/", "?", "#", "@" and space, none of which survive url.Parse unescaped, so the malformed URIs
+// this expression exists to handle are exactly the ones that carry them; excluding those bytes
+// would silently pass the password through. Being greedy anchors the match on the last "@", which
+// is what url.Parse itself treats as the end of the userinfo. The cost is over-redaction when a
+// credential-free URI happens to contain a later "@" — harmless next to leaking a password.
+var credentialsRE = regexp.MustCompile(`(mongodb(?:\+srv)?://)([^:@]*):(.*)@`)
 
 // replacement keeps the scheme and the user name and drops the password. It matches what
 // (*url.URL).Redacted does.

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -17,6 +17,7 @@ package redact
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 	"testing"
@@ -279,11 +280,13 @@ func TestErrorRedactsEveryURIInOneMessage(t *testing.T) {
 // "?" and "#" terminate the authority, so url.Parse reports on a URI it has already cut short: for
 // the password "pa#ss" the error reads `parse "mongodb://monitor:pa": invalid port ":pa"`. No "@"
 // survives for the expression to anchor on, so the part of the password before the delimiter stays
-// in the message. The URI logged beside the error is still redacted, and the full password never
-// appears, but the prefix does.
+// in the message. The full password never appears, but the prefix does.
 //
-// Closing this needs a change at the call sites -- logging the redacted URI without the raw parse
-// error -- not a wider pattern here, which could not tell "monitor:pa" from "host:27017".
+// Where the exporter builds the message it sidesteps this by not logging the parse error at all and
+// logging the redacted URI instead. Error remains for messages that come from elsewhere -- PBM
+// wraps the URI it was handed into its own text -- where dropping the error would cost the only
+// diagnostic available. Widening the pattern is not an option: it could not tell "monitor:pa" from
+// "host:27017".
 func TestErrorLeavesTruncatedURIAlone(t *testing.T) {
 	t.Parallel()
 
@@ -295,4 +298,29 @@ func TestErrorLeavesTruncatedURIAlone(t *testing.T) {
 	redacted := Error(err)
 	assert.NotContains(t, redacted, password, "the full password must never survive")
 	assert.Contains(t, redacted, "monitor:pa", "known gap: the prefix before # is still disclosed")
+}
+
+// TestErrorRedactsURIWrappedByThirdParty covers the shape percona-backup-mongodb produces: it
+// quotes the URI it was given and then wraps the *url.Error, which quotes it a second time. Both
+// copies carry the password, and the message reaches a default-level log on every scrape when
+// --collector.pbm is on.
+func TestErrorRedactsURIWrappedByThirdParty(t *testing.T) {
+	t.Parallel()
+
+	for _, password := range []string{"s3cr3t", "pa#ss", specialChars} {
+		t.Run(password, func(t *testing.T) {
+			t.Parallel()
+
+			uri := "mongodb://monitor:" + password + "@%2Ftmp%2Fmongodb.sock/admin"
+			_, parseErr := url.Parse(uri)
+			require.Error(t, parseErr)
+
+			// Reproduces the message built by percona-backup-mongodb.
+			err := fmt.Errorf("parse mongo-uri '%s': %w", uri, parseErr)
+
+			redacted := Error(err)
+			assert.NotContains(t, redacted, password)
+			assert.Contains(t, redacted, "monitor:xxxxx@")
+		})
+	}
 }

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -18,6 +18,7 @@ package redact
 import (
 	"errors"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,16 @@ import (
 )
 
 var errConnect = errors.New("cannot connect to MongoDB")
+
+// specialChars exercises the punctuation MongoDB permits in a password. Several of these bytes are
+// not representable in a URI unescaped, so they are also what drives url.Parse into the error path
+// that MongoURI has to cover on its own.
+const specialChars = `-=^?$&%#_<>*()`
+
+// specialCharsKeptByParseError is specialChars without "?" and "#". Those two end the authority, so
+// url.Parse cuts the URI at them and the error it returns quotes only the part before, which leaves
+// nothing for Error to anchor on. See TestErrorLeavesTruncatedURIAlone.
+const specialCharsKeptByParseError = `-=^$&%_<>*()`
 
 type redactTest struct {
 	name     string
@@ -49,16 +60,35 @@ func run(t *testing.T, tests []redactTest) {
 	}
 }
 
+// TestMongoURI covers the URIs url.Parse accepts, where Redacted does the work.
 func TestMongoURI(t *testing.T) {
 	t.Parallel()
 
 	//nolint:gosec // the credentials below are test fixtures.
 	run(t, []redactTest{
 		{
-			name:     "user and password",
+			name:     "simple password",
 			uri:      "mongodb://monitor:s3cr3t@127.0.0.1:27017/admin?ssl=true",
 			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin?ssl=true",
 			password: "s3cr3t",
+		}, {
+			name:     "sub-delimiters",
+			uri:      "mongodb://monitor:$&+,;=@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: "$&+,;=",
+		}, {
+			// The password separator itself. url.Parse splits userinfo on the first colon, so the
+			// rest stays in the password.
+			name:     "colon in password",
+			uri:      "mongodb://monitor:pa:ss@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: "pa:ss",
+		}, {
+			// The userinfo separator. url.Parse anchors on the last @, so this still parses.
+			name:     "at sign in password",
+			uri:      "mongodb://monitor:pa@ss@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: "pa@ss",
 		}, {
 			name:     "percent-encoded password",
 			uri:      "mongodb://monitor:p%40ss%2Fw0rd@127.0.0.1:27017/admin",
@@ -71,34 +101,67 @@ func TestMongoURI(t *testing.T) {
 			password: "s3cr3t",
 		}, {
 			name:     "multiple hosts",
-			uri:      "mongodb://monitor:s3cr3t@host1:27017,host2:27017/admin",
+			uri:      "mongodb://monitor:$&+,;=@host1:27017,host2:27017/admin",
 			expected: "mongodb://monitor:xxxxx@host1:27017,host2:27017/admin",
-			password: "s3cr3t",
-		}, {
-			name:     "no credentials",
-			uri:      "mongodb://127.0.0.1:27017/admin",
-			expected: "mongodb://127.0.0.1:27017/admin",
-			password: "",
-		}, {
-			name:     "user without password",
-			uri:      "mongodb://monitor@127.0.0.1:27017",
-			expected: "mongodb://monitor@127.0.0.1:27017",
-			password: "",
+			password: "$&+,;=",
 		},
 	})
 }
 
-// TestMongoURIUnparseable covers the inputs url.Parse rejects, where Redacted is unavailable.
+// TestMongoURIUnparseable covers the inputs url.Parse rejects, where Redacted is unavailable and
+// the fallback expression has to find the credentials on its own. Every password here contains a
+// byte that is legal in MongoDB but not in a URI.
 func TestMongoURIUnparseable(t *testing.T) {
 	t.Parallel()
 
+	//nolint:gosec // the credentials below are test fixtures.
 	run(t, []redactTest{
 		{
+			name:     "special characters",
+			uri:      "mongodb://monitor:" + specialChars + "@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: specialChars,
+		}, {
+			name:     "slash in password",
+			uri:      "mongodb://monitor:pa/ss@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: "pa/ss",
+		}, {
+			name:     "question mark in password",
+			uri:      "mongodb://monitor:pa?ss@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: "pa?ss",
+		}, {
+			name:     "hash in password",
+			uri:      "mongodb://monitor:pa#ss@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: "pa#ss",
+		}, {
+			name:     "space in password",
+			uri:      "mongodb://monitor:pa ss@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: "pa ss",
+		}, {
+			name:     "quotes in password",
+			uri:      "mongodb://monitor:p'\"s@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: "p'\"s",
+		}, {
+			name:     "special characters over srv",
+			uri:      "mongodb+srv://monitor:" + specialChars + "@cluster0.example.com/admin?replicaSet=rs1",
+			expected: "mongodb+srv://monitor:xxxxx@cluster0.example.com/admin?replicaSet=rs1",
+			password: specialChars,
+		}, {
+			name:     "special characters over multiple hosts",
+			uri:      "mongodb://monitor:" + specialChars + "@host1:27017,host2:27017/admin",
+			expected: "mongodb://monitor:xxxxx@host1:27017,host2:27017/admin",
+			password: specialChars,
+		}, {
 			// PMM escapes the path to the socket file, which url.Parse rejects.
 			name:     "socket path",
-			uri:      "mongodb://monitor:s3cr3t@%2Ftmp%2Fmongodb.sock/admin",
+			uri:      "mongodb://monitor:" + specialChars + "@%2Ftmp%2Fmongodb.sock/admin",
 			expected: "mongodb://monitor:xxxxx@%2Ftmp%2Fmongodb.sock/admin",
-			password: "s3cr3t",
+			password: specialChars,
 		}, {
 			name:     "no scheme",
 			uri:      "://///",
@@ -113,6 +176,55 @@ func TestMongoURIUnparseable(t *testing.T) {
 	})
 }
 
+// TestMongoURICredentialsHiddenByCleanParse covers the case that rules out shortcutting on a
+// successful parse: a password beginning with digits and containing a slash leaves url.Parse with a
+// valid host and port, so it reports no userinfo at all while the credentials sit in the path.
+func TestMongoURICredentialsHiddenByCleanParse(t *testing.T) {
+	t.Parallel()
+
+	const uri = "mongodb://monitor:1234/ss@127.0.0.1/admin"
+
+	parsed, err := url.Parse(uri)
+	require.NoError(t, err)
+	require.Nil(t, parsed.User, "url.Parse is expected to miss the credentials here")
+
+	assert.Equal(t, "mongodb://monitor:xxxxx@127.0.0.1/admin", MongoURI(uri))
+}
+
+// TestMongoURIWithoutCredentials checks that a URI carrying no password is left alone.
+func TestMongoURIWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	run(t, []redactTest{
+		{
+			name:     "no credentials",
+			uri:      "mongodb://127.0.0.1:27017/admin",
+			expected: "mongodb://127.0.0.1:27017/admin",
+			password: "",
+		}, {
+			name:     "user without password",
+			uri:      "mongodb://monitor@127.0.0.1:27017",
+			expected: "mongodb://monitor@127.0.0.1:27017",
+			password: "",
+		}, {
+			name:     "multiple hosts without credentials",
+			uri:      "mongodb://host1:27017,host2:27017/admin?replicaSet=rs1",
+			expected: "mongodb://host1:27017,host2:27017/admin?replicaSet=rs1",
+			password: "",
+		},
+	})
+}
+
+// TestMongoURIOverRedacts pins a known and deliberate imprecision: an at sign after the authority
+// pulls the match past the host. Since a password may contain the very bytes that would otherwise
+// delimit it, the expression cannot tell the two apart, and mangling a credential-free URI in the
+// log is the safer of the two ways to be wrong.
+func TestMongoURIOverRedacts(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "mongodb://host:xxxxx@b", MongoURI("mongodb://host:27017/db?param=a@b"))
+}
+
 func TestError(t *testing.T) {
 	t.Parallel()
 
@@ -125,14 +237,62 @@ func TestError(t *testing.T) {
 func TestErrorHidesURIQuotedByParseError(t *testing.T) {
 	t.Parallel()
 
-	password := "s3cr3t"
-	socket := "%2Ftmp%2Fmongodb.sock"
+	const socket = "%2Ftmp%2Fmongodb.sock"
 
-	_, err := url.Parse("mongodb://monitor:" + password + "@" + socket + "/admin")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), password)
+	for _, password := range []string{"s3cr3t", specialCharsKeptByParseError, "pa/ss", "pa ss"} {
+		t.Run(password, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := url.Parse("mongodb://monitor:" + password + "@" + socket + "/admin")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), password, "url.Parse is expected to quote the URI verbatim")
+
+			redacted := Error(err)
+			assert.NotContains(t, redacted, password)
+			assert.Contains(t, redacted, "mongodb://monitor:xxxxx@"+socket+"/admin")
+		})
+	}
+}
+
+// TestErrorRedactsEveryURIInOneMessage covers a message quoting more than one URI, which happens
+// when a multi-target configuration is reported in a single error. Neither password may survive.
+//
+// The match is greedy, so the two URIs collapse into one and the text between them is lost. That
+// costs detail in the log but discloses nothing, and narrowing the match would let a password
+// containing "@" through, which is the trade this package refuses to make.
+func TestErrorRedactsEveryURIInOneMessage(t *testing.T) {
+	t.Parallel()
+
+	first, second := "s3cr3t", specialCharsKeptByParseError
+	err := errors.New("cannot connect to mongodb://monitor:" + first + "@host1:27017/admin " + //nolint:err113 // test fixture.
+		"or to mongodb://backup:" + second + "@host2:27017/admin")
 
 	redacted := Error(err)
-	assert.NotContains(t, redacted, password)
-	assert.Contains(t, redacted, "mongodb://monitor:xxxxx@"+socket+"/admin")
+	assert.NotContains(t, redacted, first)
+	assert.NotContains(t, redacted, second)
+	assert.Contains(t, redacted, ":xxxxx@")
+	assert.Equal(t, 1, strings.Count(redacted, ":xxxxx@"), "greedy match is expected to collapse both URIs")
+}
+
+// TestErrorLeavesTruncatedURIAlone documents a residual gap rather than approving of it.
+//
+// "?" and "#" terminate the authority, so url.Parse reports on a URI it has already cut short: for
+// the password "pa#ss" the error reads `parse "mongodb://monitor:pa": invalid port ":pa"`. No "@"
+// survives for the expression to anchor on, so the part of the password before the delimiter stays
+// in the message. The URI logged beside the error is still redacted, and the full password never
+// appears, but the prefix does.
+//
+// Closing this needs a change at the call sites -- logging the redacted URI without the raw parse
+// error -- not a wider pattern here, which could not tell "monitor:pa" from "host:27017".
+func TestErrorLeavesTruncatedURIAlone(t *testing.T) {
+	t.Parallel()
+
+	password := "pa#ss"
+
+	_, err := url.Parse("mongodb://monitor:" + password + "@127.0.0.1:27017/admin")
+	require.Error(t, err)
+
+	redacted := Error(err)
+	assert.NotContains(t, redacted, password, "the full password must never survive")
+	assert.Contains(t, redacted, "monitor:pa", "known gap: the prefix before # is still disclosed")
 }

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,138 @@
+// mongodb_exporter
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redact
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errConnect = errors.New("cannot connect to MongoDB")
+
+type redactTest struct {
+	name     string
+	uri      string
+	expected string
+	password string
+}
+
+func run(t *testing.T, tests []redactTest) {
+	t.Helper()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := MongoURI(test.uri)
+			assert.Equal(t, test.expected, actual)
+			if test.password != "" {
+				assert.NotContains(t, actual, test.password)
+			}
+		})
+	}
+}
+
+func TestMongoURI(t *testing.T) {
+	t.Parallel()
+
+	//nolint:gosec // the credentials below are test fixtures.
+	run(t, []redactTest{
+		{
+			name:     "user and password",
+			uri:      "mongodb://monitor:s3cr3t@127.0.0.1:27017/admin?ssl=true",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin?ssl=true",
+			password: "s3cr3t",
+		}, {
+			name:     "percent-encoded password",
+			uri:      "mongodb://monitor:p%40ss%2Fw0rd@127.0.0.1:27017/admin",
+			expected: "mongodb://monitor:xxxxx@127.0.0.1:27017/admin",
+			password: "p%40ss%2Fw0rd",
+		}, {
+			name:     "srv uri",
+			uri:      "mongodb+srv://monitor:s3cr3t@cluster0.example.com/admin?replicaSet=rs1",
+			expected: "mongodb+srv://monitor:xxxxx@cluster0.example.com/admin?replicaSet=rs1",
+			password: "s3cr3t",
+		}, {
+			name:     "multiple hosts",
+			uri:      "mongodb://monitor:s3cr3t@host1:27017,host2:27017/admin",
+			expected: "mongodb://monitor:xxxxx@host1:27017,host2:27017/admin",
+			password: "s3cr3t",
+		}, {
+			name:     "no credentials",
+			uri:      "mongodb://127.0.0.1:27017/admin",
+			expected: "mongodb://127.0.0.1:27017/admin",
+			password: "",
+		}, {
+			name:     "user without password",
+			uri:      "mongodb://monitor@127.0.0.1:27017",
+			expected: "mongodb://monitor@127.0.0.1:27017",
+			password: "",
+		},
+	})
+}
+
+// TestMongoURIUnparseable covers the inputs url.Parse rejects, where Redacted is unavailable.
+func TestMongoURIUnparseable(t *testing.T) {
+	t.Parallel()
+
+	run(t, []redactTest{
+		{
+			// PMM escapes the path to the socket file, which url.Parse rejects.
+			name:     "socket path",
+			uri:      "mongodb://monitor:s3cr3t@%2Ftmp%2Fmongodb.sock/admin",
+			expected: "mongodb://monitor:xxxxx@%2Ftmp%2Fmongodb.sock/admin",
+			password: "s3cr3t",
+		}, {
+			name:     "no scheme",
+			uri:      "://///",
+			expected: "://///",
+			password: "",
+		}, {
+			name:     "empty",
+			uri:      "",
+			expected: "",
+			password: "",
+		},
+	})
+}
+
+func TestError(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, Error(nil))
+	assert.Equal(t, errConnect.Error(), Error(errConnect))
+}
+
+// TestErrorHidesURIQuotedByParseError checks the leak that makes Error necessary: url.Parse quotes
+// the whole URI in the error it returns, so logging that error alone discloses the password.
+func TestErrorHidesURIQuotedByParseError(t *testing.T) {
+	t.Parallel()
+
+	password := "s3cr3t"
+	socket := "%2Ftmp%2Fmongodb.sock"
+
+	_, err := url.Parse("mongodb://monitor:" + password + "@" + socket + "/admin")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), password)
+
+	redacted := Error(err)
+	assert.NotContains(t, redacted, password)
+	assert.Contains(t, redacted, "mongodb://monitor:xxxxx@"+socket+"/admin")
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/common/promslog"
 
 	"github.com/percona/mongodb_exporter/exporter"
+	"github.com/percona/mongodb_exporter/internal/redact"
 )
 
 //nolint:gochecknoglobals
@@ -140,7 +141,7 @@ func main() {
 
 func buildExporter(opts GlobalFlags, uri string, log *slog.Logger) *exporter.Exporter {
 	uri = buildURI(uri, opts.User, opts.Password)
-	log.Debug("Connection URI", "uri", uri)
+	log.Debug("Connection URI", "uri", redact.MongoURI(uri))
 
 	uriParsed, _ := url.Parse(uri)
 	var nodeName string
@@ -256,7 +257,7 @@ func parseURIList(uriList []string, logger *slog.Logger, splitCluster bool) []st
 		for _, hosturl := range URIs {
 			urlParsed, err := url.Parse(hosturl)
 			if err != nil {
-				log.Fatalf("Failed to parse URI %s: %v", hosturl, err)
+				log.Fatalf("Failed to parse URI %s: %v", redact.MongoURI(hosturl), redact.Error(err))
 			}
 			for _, host := range strings.Split(urlParsed.Host, ",") {
 				targetURI := "mongodb://"

--- a/main.go
+++ b/main.go
@@ -257,7 +257,10 @@ func parseURIList(uriList []string, logger *slog.Logger, splitCluster bool) []st
 		for _, hosturl := range URIs {
 			urlParsed, err := url.Parse(hosturl)
 			if err != nil {
-				log.Fatalf("Failed to parse URI %s: %v", redact.MongoURI(hosturl), redact.Error(err))
+				// The parse error is not logged: it quotes the URI cut short at the byte url.Parse
+				// choked on, and when that byte is "?" or "#" from the password, the quote keeps
+				// the part before.
+				log.Fatalf("Failed to parse URI %s", redact.MongoURI(hosturl))
 			}
 			for _, host := range strings.Split(urlParsed.Host, ",") {
 				targetURI := "mongodb://"


### PR DESCRIPTION
Fixes #1345.

MongoDB connection URIs carrying credentials were written to the logs verbatim. `buildURI` (`main.go:300`) injects the monitoring user's password into the URI, and a URI supplied via `--mongodb.uri`/`MONGODB_URI` may already embed one, so several log statements disclosed `user:password` in cleartext.

## What changed

A new `internal/redact` package holds the two helpers. The leaking call sites straddle `package main` and `package exporter`, so neither could host a shared helper; `internal/util` is MongoDB-command code and pulls in the driver, which made it a poor home for a pure string function.

- `redact.MongoURI(uri)` — `(*url.URL).Redacted()` on the happy path, keeping the username and substituting `xxxxx`.
- `redact.Error(err)` — scrubs credentials out of an error's message (see below).

Six call sites now redact:

| Location | Level |
|---|---|
| `main.go:143` — `"Connection URI"` | Debug |
| `main.go:259` — `--split-cluster` parse failure | Fatal |
| `exporter/seedlist.go:31` — URI parse failure | Fatal |
| `exporter/seedlist.go:36` — SRV lookup failure | Error |
| `exporter/seedlist.go:41` — no SRV records | Error |
| `exporter/server.go:181` — `buildServerMap` parse failure | Error |

Only the first is Debug-level; the other five fire at the **default** log level, on error paths reachable through ordinary operational failures such as a DNS hiccup or a malformed URI.

## The error argument leaked too

Three of those sites log *because* `url.Parse` failed. `url.Parse` returns a `*url.Error`, whose `Error()` quotes the offending URL **verbatim** — so the `err` argument alone disclosed the full password, and redacting only the URI argument would have fixed nothing there. Hence `redact.Error`.

This is not hypothetical. The URI PMM generates with an escaped socket path is exactly what makes `url.Parse` fail:

```
before: address=mongodb://monitor:SuperSecret123@%2F... error="parse \"mongodb://monitor:SuperSecret123@%2F...\": invalid URL escape \"%2F\""
after:  address=mongodb://monitor:xxxxx@%2F...         error="parse \"mongodb://monitor:xxxxx@%2F...\": invalid URL escape \"%2F\""
```

Where parsing failed there is no `*url.URL` to redact, so `MongoURI` falls back to a regexp that rewrites the userinfo of the raw string. The URI is kept in the message rather than dropped, because with multiple targets configured it is the only way to tell which one is malformed.

## Tests

`internal/redact/redact_test.go` is table-driven over credentialed, uncredentialed, percent-encoded, SRV, multi-host and unparseable inputs. The assertion that matters is that the password substring does not survive. `TestErrorHidesURIQuotedByParseError` first asserts that the raw `url.Parse` error really does contain the password, then that the redacted form does not — so the test would catch a future Go release that changed this behaviour.

Also verified manually against the built binary for three scenarios (credentials via `--mongodb.user`/`--mongodb.password`, credentials embedded in `--mongodb.uri`, and the socket URI), grepping the logs for the password in each.

## Not changed

`buildURI` and `buildURIManually` are untouched — injecting the credentials is intended; only logging them was wrong.

Two spots were examined and left alone: `exporter/pbm_collector.go:88` passes the URI to the third-party PBM SDK and logs only `err`, and `exporter/exporter.go:426` wraps a driver validation error whose messages quote individual option keys rather than the whole URI. Both carry residual third-party risk outside this repo's control.

Pre-existing lint findings in the touched files are left in place to keep the diff surgical. `golangci-lint run --new-from-rev=origin/main` reports 0 issues, which matches what CI's reviewdog gate (`filter_mode: added`) evaluates.

## Conflict with #1336

PR #1336 adds an unexported `redactMongoURI` to `package main` and redacts `main.go:143` as incidental cleanup. Whichever lands second needs a small rebase there — drop the local helper in favour of `internal/redact`, or re-apply that one line. No other overlap.
