### PR TITLE
fix: handle the opLatencies histogram MongoDB 8.3 added

### DIFF
--- a/exporter/feature_compatibility_version_collector_test.go
+++ b/exporter/feature_compatibility_version_collector_test.go
@@ -60,7 +60,7 @@ func TestFCVCollector(t *testing.T) {
 		mversion = "6.0"
 	case "8.0":
 		mversion = "7.0"
-	case "8.2":
+	case "8.2", "8.3":
 		mversion = "8.0"
 	default:
 		mversion = mmv

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -425,10 +425,33 @@ func appendMetricValue(metrics []prometheus.Metric, prefix, name string, value a
 	return metrics
 }
 
+// histogramBoundKeys are the fields a histogram bucket uses to name the latency range it
+// counts. Server status reports "lowerBound"; the opLatencies histograms added in MongoDB
+// 8.3 report "micros". The key becomes the label that separates one bucket from the next,
+// named after the field rather than normalised, since the two are not documented as
+// meaning the same thing.
+var histogramBoundKeys = []string{"lowerBound", "micros"}
+
+// histogramBound returns the field a bucket is keyed by, and its value.
+func histogramBound(bucket map[string]any) (string, any, bool) {
+	for _, key := range histogramBoundKeys {
+		if value, ok := bucket[key]; ok {
+			return key, value, true
+		}
+	}
+
+	return "", nil, false
+}
+
 func processHistogramSlice(prefix string, v []any, commonLabels map[string]string, compatibleMode bool) []prometheus.Metric {
 	metrics := make([]prometheus.Metric, 0, len(v))
 	for _, item := range v {
 		bucket, ok := asMetricMap(item)
+		if !ok {
+			continue
+		}
+
+		boundKey, bound, ok := histogramBound(bucket)
 		if !ok {
 			continue
 		}
@@ -438,11 +461,22 @@ func processHistogramSlice(prefix string, v []any, commonLabels map[string]strin
 			labels[name] = value
 		}
 
-		labels["lower_bound"] = fmt.Sprint(bucket["lowerBound"])
+		// Without a label naming the bucket, every bucket of the histogram produces the
+		// same series and the registry rejects all but the first.
+		labels[boundLabel(boundKey)] = fmt.Sprint(bound)
 		metrics = appendMetricValue(metrics, prefix+".", "count", bucket["count"], labels, compatibleMode)
 	}
 
 	return metrics
+}
+
+// boundLabel is the label name for a bucket keyed by boundKey.
+func boundLabel(boundKey string) string {
+	if boundKey == "lowerBound" {
+		return "lower_bound"
+	}
+
+	return boundKey
 }
 
 func isHistogramBucketSlice(prefix string, v []any) bool {
@@ -458,7 +492,7 @@ func isHistogramBucketSlice(prefix string, v []any) bool {
 		if !ok {
 			return false
 		}
-		if _, ok := bucket["lowerBound"]; !ok {
+		if _, _, ok := histogramBound(bucket); !ok {
 			return false
 		}
 		if _, ok := bucket["count"]; !ok {
@@ -469,8 +503,17 @@ func isHistogramBucketSlice(prefix string, v []any) bool {
 	return true
 }
 
+// isHistogramPath reports whether prefix names a histogram subtree. Both spellings occur:
+// server status uses "histograms", while the opLatencies histograms added in MongoDB 8.3
+// use "histogram".
 func isHistogramPath(prefix string) bool {
-	return prefix == "histograms" || strings.Contains(prefix, ".histograms.") || strings.HasSuffix(prefix, ".histograms") //nolint:goconst
+	for _, name := range []string{"histograms", "histogram"} {
+		if prefix == name || strings.Contains(prefix, "."+name+".") || strings.HasSuffix(prefix, "."+name) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func asMetricMap(item any) (map[string]any, bool) {

--- a/exporter/metrics_test.go
+++ b/exporter/metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -313,4 +314,76 @@ func TestAsMetricMapHandlesBSONM(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, int64(1024), bucket["lowerBound"])
 	assert.Equal(t, int64(7), bucket["count"])
+}
+
+// MongoDB 8.3 added a histogram to serverStatus().opLatencies. Its buckets are keyed by
+// "micros" rather than "lowerBound", and the field is spelled "histogram" rather than
+// "histograms", so neither the bucket shape nor the path was recognised: every bucket
+// produced the same series and the registry rejected all but the first, one error per
+// bucket per scrape.
+func TestOpLatenciesHistogramBucketsDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	metrics := makeMetricsWithHistograms("serverStatus.opLatencies.commands", bson.M{
+		"histogram": primitive.A{
+			bson.M{"micros": int64(8), "count": int64(3)},
+			bson.M{"micros": int64(64), "count": int64(7)},
+			bson.M{"micros": int64(512), "count": int64(11)},
+		},
+		"latency": int64(1234),
+		"ops":     int64(5),
+	}, nil, true, true)
+
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(staticCollector(metrics))
+
+	gatheredMetrics, err := reg.Gather()
+	require.NoError(t, err, "metrics with the same name and labels must not be exported")
+
+	metricsByName := make(map[string]*dto.MetricFamily, len(gatheredMetrics))
+	for _, metric := range gatheredMetrics {
+		metricsByName[metric.GetName()] = metric
+	}
+
+	// The bucket bound is a label, not a measurement of its own.
+	assert.NotContains(t, metricsByName, "mongodb_ss_opLatencies_commands_histogram_micros")
+
+	bucketCounts, ok := metricsByName["mongodb_ss_opLatencies_commands_histogram_count"]
+	if !assert.True(t, ok) {
+		return
+	}
+
+	valuesByBound := make(map[string]float64, len(bucketCounts.GetMetric()))
+	for _, metric := range bucketCounts.GetMetric() {
+		valuesByBound[metricLabels(metric)["micros"]] = metric.GetCounter().GetValue()
+	}
+
+	assert.Equal(t, map[string]float64{
+		"8":   3,
+		"64":  7,
+		"512": 11,
+	}, valuesByBound)
+
+	// Siblings of the histogram are still reported. nodeToPDMetrics turns the op name into a
+	// label for these, which is why they are not scoped by "commands" the way the bucket
+	// counts are.
+	assert.Contains(t, metricsByName, "mongodb_ss_opLatencies_latency")
+	assert.Contains(t, metricsByName, "mongodb_ss_opLatencies_ops")
+}
+
+// The singular spelling is gated like the plural one, so enabling histograms stays the one
+// switch that decides whether bucket series are exported.
+func TestOpLatenciesHistogramSkippedByDefault(t *testing.T) {
+	t.Parallel()
+
+	metrics := makeMetrics("serverStatus.opLatencies.commands", bson.M{
+		"histogram": primitive.A{
+			bson.M{"micros": int64(8), "count": int64(3)},
+		},
+		"ops": int64(5),
+	}, nil, true)
+
+	for _, metric := range metrics {
+		assert.NotContains(t, metric.Desc().String(), "histogram")
+	}
 }


### PR DESCRIPTION
Closes #1285.

The `mongo:latest` CI leg started failing when the floating tag rolled to MongoDB **8.3.8**. Three tests, two root causes — one of them a real exporter bug that also affects production.

## `opLatencies.histogram` produced colliding series

MongoDB 8.3 added a histogram to `serverStatus().opLatencies`. On 8.2 that subtree has only `latency`, `ops` and `queryableEncryptionLatencyMicros`; I confirmed this against a live 8.2.12:

```
$ mongosh --eval 'Object.keys(db.serverStatus().opLatencies.commands)'
[ 'latency', 'ops', 'queryableEncryptionLatencyMicros' ]
```

Two things about the new array went unrecognised:

- the field is spelled `histogram`, while `isHistogramPath` matched only the plural `histograms`;
- its buckets are keyed by `micros`, while `isHistogramBucketSlice` accepted only `lowerBound`.

So it fell through to `processSlice`, which labels array members by `name`, `stateStr` or `host` — none of which a bucket has. Every bucket then produced an identically-labelled series and the registry rejected all but the first:

```
gathering metrics failed: 64 error(s) occurred:
* collected metric "mongodb_ss_opLatencies_commands_histogram_micros" { untyped:{value:8}} was collected before with the same name and label values
* collected metric "mongodb_ss_opLatencies_commands_histogram_count" { counter:{value:1813}} was collected before with the same name and label values
...
```

That is exactly #1285, which reports the same errors from a production exporter against 8.3.1.

Bucket detection now accepts either bound key, and the bound becomes a label as it already did for `lowerBound`. Each bucket gets its own series, and the bound stops being exported as a measurement of its own.

One judgement call: the label is named `micros`, after the field, rather than folded into the existing `lower_bound`. The two are not documented as meaning the same thing, and I could not start MongoDB 8.3 locally to check (see below), so I would rather not assert an equivalence I have not verified. Happy to switch to `lower_bound` if you know it is the inclusive lower bound.

The singular spelling is now gated by `--collector.diagnosticdata-histograms` like the plural one. That is a behaviour change worth naming: these bucket series are no longer exported by default. They are not a loss, since today they are dropped by the registry anyway — the only thing they produce is one error per bucket per scrape.

## `TestFCVCollector` had no case for 8.3

`exporter/feature_compatibility_version_collector_test.go` maps the server version to the FCV it expects. The table stopped at `8.2`, so 8.3 fell through to `default` and expected FCV `8.3`, while the CI cluster reports `8.0`. Folded `8.3` in with the existing `8.2` case.

For the record, since the direction of a `CollectAndCompare` diff is easy to get backwards: `compare` calls `diff.Diff(got, want)`, and godebug marks lines present in the first argument with `-`. So in

```
-mongodb_fcv_feature_compatibility_version{version="8.0"} 8
+mongodb_fcv_feature_compatibility_version{version="8.3"} 8.3
```

`8.0` is what the 8.3.8 cluster actually reported. I checked that orientation empirically rather than by reading: running this test against a fresh single-node 8.2 gives `-…{version="8.2"} 8.2` / `+…{version="8.0"} 8`, and 8.2 is unmistakably that server's real FCV.

That also shows the existing `8.2 → 8.0` entry is calibrated to the CI cluster topology, not to a fresh node — a fresh 8.2 node reports FCV 8.2. Worth knowing before anyone tries to run this test outside the compose cluster.

## Verification

What I could check locally:

- **The new unit tests reproduce the CI failure with no server at all.** `TestOpLatenciesHistogramBucketsDoNotCollide` feeds the 8.3 shape through `makeMetricsWithHistograms` into a pedantic registry. Against `main`'s `exporter/metrics.go` it fails with the same error text and the same metric names as CI; with the fix it passes.
- **No regression on 8.2.** `TestDiagnosticDataCollector` and `TestAllDiagnosticDataCollectorMetrics` pass against a live 8.2.12 replica set, as do the existing `TestHistogramMetrics*` tests for the `lowerBound` shape.
- `go build`, `go vet`, `make format` and `golangci-lint run --new-from-rev=main` are clean.

What I could **not** check: no MongoDB 8.3 build starts on this machine. Every 8.3 tag from `8.3.0-rc5` to `8.3.8` refuses:

```
MongoDB cannot start: Linux kernel versions 6.19 and newer has a known
incompatibility with this version of MongoDB. See SERVER-121912
```

The Docker VM kernel here is 7.0.12; GitHub runners are below that threshold, which is why CI runs it fine. So the 8.3 half of this rests on the CI log plus the synthetic unit tests, not on a live 8.3 server. The `mongo:latest` leg of this PR's own CI is the real check.
