### PR TITLE
ci: reuse the Go module cache in the dry-run and migrate to dockers_v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      # Without a GoReleaser on PATH, release-dry-run falls back to running it in a container
-      # that mounts only the source tree, so the module cache "Set up Go" just restored is
-      # invisible and every target re-downloads every dependency. Installing it here also makes
-      # the dry-run use the same GoReleaser stream and the same Go as the release job, rather
-      # than whatever goreleaser/goreleaser:latest happens to carry.
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,17 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
+      # Without a GoReleaser on PATH, release-dry-run falls back to running it in a container
+      # that mounts only the source tree, so the module cache "Set up Go" just restored is
+      # invisible and every target re-downloads every dependency. Installing it here also makes
+      # the dry-run use the same GoReleaser stream and the same Go as the release job, rather
+      # than whatever goreleaser/goreleaser:latest happens to carry.
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: "~> v2"
+          install-only: true
+
       - name: Dry-run GoReleaser
         run: |
           make release-dry-run

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,52 +34,21 @@ release:
     name: mongodb_exporter
   draft: true
   prerelease: auto
-dockers:
-- goos: linux
-  goarch: amd64
-  image_templates:
-  - "docker.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}-amd64"
-  - "docker.io/percona/mongodb_exporter:{{.Version}}-amd64"
-  - "ghcr.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}-amd64"
-  - "ghcr.io/percona/mongodb_exporter:{{.Version}}-amd64"
-  dockerfile: Dockerfile
-  use: buildx
-  build_flag_templates:
-    - "--pull"
-    - "--platform=linux/amd64"
-- goos: linux
-  goarch: arm64
-  image_templates:
-  - "docker.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}-arm64v8"
-  - "docker.io/percona/mongodb_exporter:{{.Version}}-arm64v8"
-  - "ghcr.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}-arm64v8"
-  - "ghcr.io/percona/mongodb_exporter:{{.Version}}-arm64v8"
-  dockerfile: Dockerfile
-  use: buildx
-  build_flag_templates:
-    - "--pull"
-    - "--platform=linux/arm64/v8"
-docker_manifests:
-## Docker Hub
-  - name_template: docker.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}
-    image_templates:
-    - docker.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}-arm64v8
-    - docker.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}-amd64
-
-  - name_template: docker.io/percona/mongodb_exporter:{{.Version}}
-    image_templates:
-    - docker.io/percona/mongodb_exporter:{{.Version}}-arm64v8
-    - docker.io/percona/mongodb_exporter:{{.Version}}-amd64
-## GHCR
-  - name_template: ghcr.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}
-    image_templates:
-    - ghcr.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}-arm64v8
-    - ghcr.io/percona/mongodb_exporter:{{.Major}}.{{.Minor}}-amd64
-
-  - name_template: ghcr.io/percona/mongodb_exporter:{{.Version}}
-    image_templates:
-    - ghcr.io/percona/mongodb_exporter:{{.Version}}-arm64v8
-    - ghcr.io/percona/mongodb_exporter:{{.Version}}-amd64
+dockers_v2:
+  - ids:
+      - mongodb_exporter
+    images:
+      - docker.io/percona/mongodb_exporter
+      - ghcr.io/percona/mongodb_exporter
+    tags:
+      - "{{.Major}}.{{.Minor}}"
+      - "{{.Version}}"
+    dockerfile: Dockerfile
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    flags:
+      - "--pull"
 
 nfpms:
   - file_name_template: "{{ .ProjectName }}-{{ .Version }}.{{ .Os }}-{{- if eq .Arch `amd64` }}64-bit{{- else }}{{ .Arch }}{{ end }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM alpine AS builder
 RUN apk add --no-cache ca-certificates
 
 FROM scratch AS final
+ARG TARGETPLATFORM
+# GoReleaser stages the binaries under $TARGETPLATFORM in its build context;
+# `make docker-build` overrides BIN_DIR with the local build path instead.
+ARG BIN_DIR=$TARGETPLATFORM
 USER 65535:65535
 COPY  --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY ./mongodb_exporter /
+COPY $BIN_DIR/mongodb_exporter /
 EXPOSE 9216
 ENTRYPOINT ["/mongodb_exporter"]

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ build:                      ## Build exporter binary using plain go build.
 	CGO_ENABLED=0 go build -ldflags="$(GO_BUILD_LDFLAGS)"  -o $(PMM_RELEASE_PATH)/mongodb_exporter
 
 docker-build: build
-	docker build -t ${NAME}:${IMAGE_TAG} .
+	docker build -t ${NAME}:${IMAGE_TAG} --build-arg BIN_DIR=$(PMM_RELEASE_PATH) .
 
 build-gssapi:                      ## Build exporter binary with GSSAPI support (requires CGO enabled).
 	CGO_ENABLED=1 go build -ldflags="$(GO_BUILD_LDFLAGS)" -tags gssapi  -o $(PMM_RELEASE_PATH)/mongodb_exporter

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ build
 If you built the exporter using the method mentioned in the previous section, the generated binaries are in `build/mongodb_exporter_linux_amd64_v1/mongodb_exporter` or `build/mongodb_exporter_darwin_arm64_v8.0/mongodb_exporter`
 
 #### Docker
-A docker image is available on the [official percona repository](https://hub.docker.com/r/percona/mongodb_exporter).
-It is a multi-architecture image covering `linux/amd64` and `linux/arm64`, so the same tag works on both.
+Images are published to the [official percona repository](https://hub.docker.com/r/percona/mongodb_exporter) on Docker Hub
+and to [GHCR](https://github.com/percona/mongodb_exporter/pkgs/container/mongodb_exporter). Both carry the same tags and are
+multi-architecture, covering `linux/amd64` and `linux/arm64`, so a single tag works on either platform.
 
 ##### Examples
 
@@ -77,6 +78,9 @@ podman run -d -p 9216:9216 percona/mongodb_exporter:0.53 --mongodb.uri=mongodb:/
 
 # with docker
 docker run -d -p 9216:9216 percona/mongodb_exporter:0.53 --mongodb.uri=mongodb://127.0.0.1:17001
+
+# from GHCR instead of Docker Hub
+docker run -d -p 9216:9216 ghcr.io/percona/mongodb_exporter:0.53 --mongodb.uri=mongodb://127.0.0.1:17001
 ```
 
 ### Permissions

--- a/README.md
+++ b/README.md
@@ -35,30 +35,48 @@ the current version.
 The build process uses the dockerized version of goreleaser so you don't need to install Go.
 Just run `make release` and the new binaries will be generated under the build directory.
 ```
-├── build
-│ ├── config.yaml
-│ ├── mongodb_exporter_7c73946_checksums.txt
-│ ├── mongodb_exporter-7c73946.darwin-amd64.tar.gz
-│ ├── mongodb_exporter-7c73946.linux-amd64.tar.gz
-│ ├── mongodb_exporter_darwin_amd64
-│ │ └── mongodb_exporter <--- MacOS binary
-│ └── mongodb_exporter_linux_amd64
-│ └── mongodb_exporter <--- Linux binary
+build
+├── config.yaml
+├── mongodb_exporter_7c73946_checksums.txt
+├── mongodb_exporter-7c73946.darwin-amd64.tar.gz
+├── mongodb_exporter-7c73946.darwin-arm64.tar.gz
+├── mongodb_exporter-7c73946.linux-amd64.tar.gz
+├── mongodb_exporter-7c73946.linux-arm64.tar.gz
+├── mongodb_exporter-7c73946.linux-arm.tar.gz
+├── mongodb_exporter-7c73946.linux-64-bit.deb
+├── mongodb_exporter-7c73946.linux-64-bit.rpm
+├── mongodb_exporter-7c73946.linux-arm64.deb
+├── mongodb_exporter-7c73946.linux-arm64.rpm
+├── mongodb_exporter-7c73946.linux-arm.deb
+├── mongodb_exporter-7c73946.linux-arm.rpm
+├── mongodb_exporter_darwin_amd64_v1
+│   └── mongodb_exporter    <--- macOS Intel binary
+├── mongodb_exporter_darwin_arm64_v8.0
+│   └── mongodb_exporter    <--- macOS Apple silicon binary
+├── mongodb_exporter_linux_amd64_v1
+│   └── mongodb_exporter    <--- Linux x86_64 binary
+├── mongodb_exporter_linux_arm64_v8.0
+│   └── mongodb_exporter    <--- Linux arm64 binary
+└── mongodb_exporter_linux_arm_7
+    └── mongodb_exporter    <--- Linux armv7 binary
 ```
+`7c73946` is the short commit hash — snapshot builds are versioned by commit.
+
 ### Running the exporter
-If you built the exporter using the method mentioned in the previous section, the generated binaries are in `mongodb_exporter_linux_amd64/mongodb_exporter` or `mongodb_exporter_darwin_amd64/mongodb_exporter`
+If you built the exporter using the method mentioned in the previous section, the generated binaries are in `build/mongodb_exporter_linux_amd64_v1/mongodb_exporter` or `build/mongodb_exporter_darwin_arm64_v8.0/mongodb_exporter`
 
 #### Docker
 A docker image is available on the [official percona repository](https://hub.docker.com/r/percona/mongodb_exporter).
+It is a multi-architecture image covering `linux/amd64` and `linux/arm64`, so the same tag works on both.
 
 ##### Examples
 
 ```sh
 # with podman
-podman run -d -p 9216:9216 percona/mongodb_exporter:0.40 --mongodb.uri=mongodb://127.0.0.1:17001
+podman run -d -p 9216:9216 percona/mongodb_exporter:0.53 --mongodb.uri=mongodb://127.0.0.1:17001
 
 # with docker
-docker run -d -p 9216:9216 percona/mongodb_exporter:0.40 --mongodb.uri=mongodb://127.0.0.1:17001
+docker run -d -p 9216:9216 percona/mongodb_exporter:0.53 --mongodb.uri=mongodb://127.0.0.1:17001
 ```
 
 ### Permissions
@@ -97,18 +115,18 @@ More info about roles in MongoDB [documentation](https://docs.mongodb.com/manual
 
 #### Example
 ```sh
-mongodb_exporter_linux_amd64/mongodb_exporter --mongodb.uri=mongodb://127.0.0.1:17001
+build/mongodb_exporter_linux_amd64_v1/mongodb_exporter --mongodb.uri=mongodb://127.0.0.1:17001
 ```
 
 #### MongoDB Authentication
 You can supply the mongodb user/password direct in the `--mongodb.uri=` like `--mongodb.uri=mongodb://user:pass@127.0.0.1:17001`, you can also supply the mongodb user/password with `--mongodb.user=`, `--mongodb.password=`
 but the user and password info will be leaked via `ps` or `top` command, for security issue, you can use `MONGODB_USER` and `MONGODB_PASSWORD` env variable to set user/password for given uri
 ```sh
-MONGODB_USER=XXX MONGODB_PASSWORD=YYY mongodb_exporter_linux_amd64/mongodb_exporter --mongodb.uri=mongodb://127.0.0.1:17001 --mongodb.collstats-colls=db1.c1,db2.c2
+MONGODB_USER=XXX MONGODB_PASSWORD=YYY build/mongodb_exporter_linux_amd64_v1/mongodb_exporter --mongodb.uri=mongodb://127.0.0.1:17001 --mongodb.collstats-colls=db1.c1,db2.c2
 # or
 export MONGODB_USER=XXX
 export MONGODB_PASSWORD=YYY
-mongodb_exporter_linux_amd64/mongodb_exporter --mongodb.uri=mongodb://127.0.0.1:17001 --mongodb.collstats-colls=db1.c1,db2.c2
+build/mongodb_exporter_linux_amd64_v1/mongodb_exporter --mongodb.uri=mongodb://127.0.0.1:17001 --mongodb.collstats-colls=db1.c1,db2.c2
 ```
 
 #### Multi-target support
@@ -143,7 +161,7 @@ mongodb_up{instance="host2:27016"} 1
 `--mongodb.collstats-colls` receives a list of databases and collections to monitor using collstats.
 Usage example: `--mongodb.collstats-colls=database1.collection1,database2.collection2`
 ```sh
-mongodb_exporter_linux_amd64/mongodb_exporter --mongodb.uri=mongodb://127.0.0.1:17001 --mongodb.collstats-colls=db1.c1,db2.c2
+build/mongodb_exporter_linux_amd64_v1/mongodb_exporter --mongodb.uri=mongodb://127.0.0.1:17001 --mongodb.collstats-colls=db1.c1,db2.c2
 ```
 #### Enabling compatibility mode.
 When compatibility mode is enabled by the `--compatible-mode`, the exporter will expose all new metrics with the new naming and labeling schema and at the same time will expose metrics in the version 1 compatible way.


### PR DESCRIPTION
Four commits: two independent GoReleaser changes, plus README fixes noticed while checking whether the second one had any doc surface.

---

# 1. Reuse the Go module cache in the dry-run

## Problem

The `Dry-run GoReleaser` step downloads every Go module from scratch on every run, even though `Set up Go` has already restored the module cache. It is the slowest step in the `Build` workflow at **5m15s** ([run 33950501265](https://github.com/percona/mongodb_exporter/actions/runs/33950501265/job/101264240079)).

`release-dry-run` prefers a GoReleaser on `PATH` and otherwise falls back to a container:

https://github.com/percona/mongodb_exporter/blob/main/Makefile#L90-L101

Nothing installs GoReleaser on the runner, so the fallback always wins:

```
GoReleaser not found. Installing via Docker...
Unable to find image 'goreleaser/goreleaser:latest' locally
```

That container mounts only the source tree and the docker socket. Its `GOMODCACHE` is `/go/pkg/mod` (the image sets `GOPATH=/go`), which has nothing to do with the cache the runner restored:

```
/home/runner/go/pkg/mod
Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.7-03dc7db3...
Cache Size: ~678 MB (710701637 B)
Cache restored successfully
```

The cache is fine — it hit on the primary key. The container simply cannot see it.

The log makes the cost unambiguous. Four targets build concurrently against a cold cache and between them emit **454 `go: downloading` lines** (113 / 114 / 112 / 115 — the same ~115 modules, four times over). The fifth target, `darwin_arm64`, runs after the container's cache has warmed and downloads **nothing**:

| segment | time |
|---|---|
| pull `goreleaser/goreleaser:latest` | 13.6s |
| 4 targets, cold module cache | ~4m0s |
| 5th target, warm module cache | 59s |

## Change

Install GoReleaser before the step, using the action, version constraint and pinned SHA that `release.yml` already uses. The Makefile's native branch then takes over and GoReleaser drives the runner's own Go, which reads the restored cache directly. No Makefile change.

## Why this and not a cache mount

Mounting `GOMODCACHE` into the container would also work, but it needs `-u $(id -u):$(id -g)` to avoid leaving root-owned files in the runner's cache, and the image's entrypoint has not been checked against a non-root uid. Installing natively avoids that entirely and is a smaller diff.

It also makes the dry-run a more honest rehearsal of the release, which is worth more than the minutes saved:

| | GoReleaser | Go |
|---|---|---|
| `build.yml` before | `goreleaser:latest`, unpinned | 1.27.0, from the image |
| `release.yml` | `~> v2` | 1.26.7, from `go.mod` |
| `build.yml` after | `~> v2` | 1.26.7, from `go.mod` |

`--privileged` and the docker socket mount also drop off the PR path. `goreleaser build` never runs the Docker pipe — `.goreleaser.yml` scopes that to `release` — so neither was doing anything.

## Expected saving

The image pull (13.6s) plus fetching 139 module zips totalling 187MB. GoReleaser buffers each build's output and flushes it at completion, so the log carries no per-download timing and download time cannot be separated from compile time. On that evidence the honest estimate is **1–2 minutes off a 5m15s step**, not more. The before/after on this PR's own `Build` run is the real measurement.

## Not addressed here

The dry-run cross-compiles five targets on every PR, which is roughly four of the five minutes and dwarfs the cache question. Restricting PRs to `linux_amd64` and keeping the full matrix for `main` and tags would save far more, but that is a policy call about how much cross-compile breakage should be caught before merge.

---

# 2. Migrate the Docker config to `dockers_v2`

## Problem

`goreleaser check` emits a deprecation notice for each `dockers` entry:

```
• setting defaults
  • dockers and docker_manifests are being phased out and will eventually be replaced
    by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info
  • dockers and docker_manifests are being phased out and will eventually be replaced
    by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info
```

They will be removed in GoReleaser v3.

## Change

`dockers_v2` replaces both sections with a single entry — 46 lines become 15. Buildx is implicit (no `use:`), the platforms move out of `--platform=` build flags into `platforms:`, and one `buildx build --push` produces the multi-arch manifest instead of two per-arch builds followed by a separate manifest pass.

The build context also changed shape. The old pipe put artifacts flat at the context root; `dockers_v2` stages them under `$TARGETPLATFORM/`, so the `Dockerfile` copies from there:

```dockerfile
ARG TARGETPLATFORM
ARG BIN_DIR=$TARGETPLATFORM
COPY $BIN_DIR/mongodb_exporter /
```

`make docker-build` builds one native binary at `PMM_RELEASE_PATH` and has no platform directory, so it passes `--build-arg BIN_DIR=$(PMM_RELEASE_PATH)` and keeps working unchanged.

## Breaking: the per-arch tags are dropped

`dockers_v2` publishes one manifest per tag rather than per-arch images plus a manifest, so the suffixed tags stop being produced. On **both** `docker.io/percona/mongodb_exporter` and `ghcr.io/percona/mongodb_exporter`:

| tag | before | after |
|---|---|---|
| `:{Major}.{Minor}` | manifest (amd64 + arm64) | unchanged |
| `:{Version}` | manifest (amd64 + arm64) | unchanged |
| `:{Major}.{Minor}-amd64` | single-arch image | no longer published |
| `:{Version}-amd64` | single-arch image | no longer published |
| `:{Major}.{Minor}-arm64v8` | single-arch image | no longer published |
| `:{Version}-arm64v8` | single-arch image | no longer published |

Tags already on Docker Hub and GHCR stay where they are; they just stop getting new versions. Anyone pulling `:0.4x` or `:0.4x.y` is unaffected — Docker resolves the right architecture from the manifest. Keeping the suffixed tags is possible with two extra single-platform `dockers_v2` entries, at the cost of building and pushing every layer twice; that seemed a poor trade for tags the manifest already covers, but say so if you disagree.

## Behaviour change: images move to the publish phase

Buildx cannot create a multi-platform manifest locally without pushing it, so `dockers_v2` builds and pushes in one step during **publish**. Consequences:

- `release.yml` runs `goreleaser release --clean`, which includes publish — the actual release is unaffected.
- `make release` (`release --snapshot --skip=publish`) no longer builds images at all.
- `make release-dry-run` (`goreleaser build`) never built them, so PR coverage is unchanged.

The practical effect is that **no CI job exercises the image build**; it first runs on a tagged release. That is why this was verified locally instead.

## Verification

GoReleaser v2.18.0 locally:

- `goreleaser check` — clean, no deprecation notices.
- `goreleaser release --snapshot --clean` — the Docker pipe built both platforms and produced the expected images.
- `docker run --rm --platform linux/{amd64,arm64} ... --version` — both images start and report the right version.
- `make docker-build` — still succeeds.

## Caveat

GoReleaser's docs still label `dockers_v2` alpha ("will be improved until deemed stable"), even though the deprecation notice points at it. The config shape may shift before v3.

---

# 3. README fixes

Pre-existing, unrelated to the two changes above, but cheap to fold in rather than open a second PR.

**Every runnable command in the README pointed at a path that does not exist.** GoReleaser appends the microarchitecture level to each output directory, so `mongodb_exporter_linux_amd64/mongodb_exporter` is really `build/mongodb_exporter_linux_amd64_v1/mongodb_exporter`. Fixed in five places, now prefixed with `build/` so they work from the repo root.

**The build tree was amd64-only** and predated the arm64/armv7 targets and the deb/rpm packages. Replaced with the real output of `make release`.

**The Docker examples pinned `:0.40`**, six minor versions behind — the latest release is v0.53.0. Bumped to `:0.53` and noted that the image is multi-arch, which matters more now that the per-arch tags are gone.

## GHCR is now documented as well

`.goreleaser.yml` has pushed to `ghcr.io/percona/mongodb_exporter` on every release since 2022, and the package has **106 versions** — but its visibility was `private`, so anonymous pulls got `DENIED` and the package page 404'd for logged-out users. Six years of pushes nobody outside the org could consume, and the README understandably never mentioned it.

The package was made public while this PR was open, so the last commit documents it alongside Docker Hub. Verified with no credentials:

```
$ docker pull -q ghcr.io/percona/mongodb_exporter:0.53 &&
  docker run --rm ghcr.io/percona/mongodb_exporter:0.53 --version
mongodb_exporter - MongoDB Prometheus exporter
Version: v0.53.0
Commit: 48208f2
Build date: 2026-08-20T10:24:18Z

$ docker buildx imagetools inspect ghcr.io/percona/mongodb_exporter:0.53
  Platform:  linux/amd64
  Platform:  linux/arm64
```
