### PR TITLE
Fix compatibility replication lag sign for stale primary optimes

### DIFF
--- a/exporter/replset_lag_test.go
+++ b/exporter/replset_lag_test.go
@@ -1,0 +1,83 @@
+// mongodb_exporter
+// Copyright (C) 2026 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestReplSetMetricsReplicationLag(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		primary     int64
+		secondary   int64
+		omitPrimary bool
+		wantLag     string
+	}{
+		{name: "secondary newer than primary heartbeat", primary: 1000, secondary: 1010, wantLag: "0"},
+		{name: "secondary caught up", primary: 1000, secondary: 1000, wantLag: "0"},
+		{name: "secondary behind primary", primary: 1017, secondary: 1000, wantLag: "17"},
+		{name: "delayed secondary", primary: 1060, secondary: 1000, wantLag: "60"},
+		{name: "no primary", secondary: 1000, omitPrimary: true},
+		{name: "primary optime unavailable", secondary: 1000},
+		{name: "secondary optime unavailable", primary: 1000},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			members := bson.A{bson.M{
+				"name":       "secondary:27017",
+				"stateStr":   "SECONDARY",
+				"health":     1,
+				"self":       true,
+				"optimeDate": primitive.DateTime(tc.secondary * 1000),
+			}}
+			if !tc.omitPrimary {
+				members = append(members, bson.M{
+					"name":       "primary:27017",
+					"stateStr":   "PRIMARY",
+					"health":     1,
+					"optimeDate": primitive.DateTime(tc.primary * 1000),
+				})
+			}
+
+			metrics := replSetMetrics(bson.M{"set": "rs0", "members": members}, promslog.New(&promslog.Config{}))
+			var expected string
+			if tc.wantLag != "" {
+				expected = fmt.Sprintf(`
+# HELP mongodb_mongod_replset_member_replication_lag The replication lag that this member has with the primary.
+# TYPE mongodb_mongod_replset_member_replication_lag gauge
+mongodb_mongod_replset_member_replication_lag{name="secondary:27017",self="1",set="rs0",state="SECONDARY"} %s
+`, tc.wantLag)
+			}
+
+			err := testutil.CollectAndCompare(staticCollector(metrics), strings.NewReader(expected), "mongodb_mongod_replset_member_replication_lag")
+			require.NoError(t, err)
+		})
+	}
+}

--- a/exporter/v1_compatibility.go
+++ b/exporter/v1_compatibility.go
@@ -1038,7 +1038,8 @@ func replSetMetrics(d bson.M, l *slog.Logger) []prometheus.Metric { //nolint:cyc
 				float64(m.ElectionTime.T), labels)
 		}
 		if t := m.OptimeDate.Time(); gotPrimary && t.Unix() != 0 && m.StateStr != "PRIMARY" {
-			val := math.Abs(float64(t.Unix() - primaryOpTime.Unix()))
+			// A member can be newer than the heartbeat-reported primary optime without being behind.
+			val := math.Max(0, float64(primaryOpTime.Unix()-t.Unix()))
 			createMetric("member_replication_lag",
 				"The replication lag that this member has with the primary.",
 				val, labels)


### PR DESCRIPTION
Fixes #1362.

When scraped on a secondary, `replSetGetStatus` can contain a local applied optime newer than the heartbeat-reported primary optime. The compatibility lag metric currently takes the absolute difference, so a secondary 10 seconds newer than that cached primary timestamp incorrectly reports 10 seconds of lag.

Calculate `max(0, primaryOptime - memberOptime)` instead. This preserves positive lag, the existing metric name and labels, and the guards that omit lag when no primary is found or either optime is unavailable. Remote-member data still depends on heartbeat freshness.

Add a deterministic test that exercises `replSetMetrics` and checks the emitted Prometheus metric for seven cases: newer secondary, caught-up secondary, lagging secondary, delayed secondary, no primary, missing primary optime, and missing secondary optime. It uses synthetic BSON data and needs no MongoDB connection. The newer-secondary case fails on unmodified `main` with 10 instead of 0; all seven pass with this fix.

Validation with Go 1.26.7:

- Regression plus the existing compatibility-conversion and metric unit tests passed, including with `-race`.
- `make format`, `make check-license`, and `git diff --check` passed.
- golangci-lint v2.13.1 reports zero issues introduced by this patch (`--new-from-rev=49408b0b904b1b34b4e0924f85bf7ebe6b2e76fb`). A full unfiltered lint run also reports existing findings outside the change.
- The Docker-based MongoDB integration suite was not run locally; upstream CI remains to be run.

Focused regression command:

```sh
go test -race ./exporter -run '^TestReplSetMetricsReplicationLag$' -count=1 -v
```

Related: #697 concerns unavailable members and zero timestamps; this fix addresses a different case involving healthy members with nonzero timestamps.
